### PR TITLE
Fixed zope.app.component namespace error

### DIFF
--- a/collective/dancing/utils.py
+++ b/collective/dancing/utils.py
@@ -7,6 +7,8 @@ import stoneagehtml
 import z3c.form.interfaces
 from zope.interface import noLongerProvides
 import zope.schema.vocabulary
+
+# dep to zope.app.component was dropped in Plone 4.3
 try:
     from zope.app.component.hooks import getSite
 except ImportError:


### PR DESCRIPTION
In Plone 4.3 package zope.app.component was moved into zope.component
