### PR TITLE
Add a dispatcher that uses Plone's MailHost directly

### DIFF
--- a/collective/dancing/browser.txt
+++ b/collective/dancing/browser.txt
@@ -21,8 +21,15 @@ Setup
 
 We want messages to be printed out instead of sending them:
 
-  >>> from collective.dancing.tests import setup_testing_maildelivery
-  >>> delivery = setup_testing_maildelivery()
+  >>> from collective.dancing.tests import MockMailHost
+  >>> from Products.MailHost.interfaces import IMailHost
+  >>> self.portal._delObject('MailHost')
+  >>> mail_host = MockMailHost('MailHost')
+  >>> self.portal._setObject('MailHost', mail_host)
+  'MailHost'
+  >>> self.portal.MailHost
+  <MockMailHost at /plone/>
+  >>> delivery = self.portal.MailHost
 
 Control panel
 -------------
@@ -752,6 +759,24 @@ If sending the message fails, we'll get notified:
   >>> "0 message(s) sent" in browser.contents
   True
 
+Test Dispatch from collective.dancing that used MailHost:
+
+  >>> import email
+  >>> test_message = email.Message.Message()
+  >>> test_message['From'] = 'daniel@testingunderground.com'
+  >>> test_message['To'] = 'plone-users@lists.sourceforge.net'
+  >>> test_message.set_payload('Hello, Plone users!')
+  >>> from collective.dancing.composer import Dispatch
+  >>> component.provideAdapter(Dispatch)
+  >>> dispatcher = Dispatch(test_message)
+  >>> dispatcher() \
+  ... # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  *TestingMailDelivery sending*:
+  From: daniel@testingunderground.com
+  To: plone-users@lists.sourceforge.net
+  Message follows:
+  ...
+  (u'sent', None)
 
 Subscribe
 ---------
@@ -925,14 +950,13 @@ sent:
   *TestingMailDelivery sending*:
   ...
   (3, 0)
-
   >>> print delivery.last_messages(purge=False) \
   ... # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
   Content-Type: multipart/mixed;
   ...
   Subject: Plone site: My other channel...
+  To: daniel@domain.tld...
   From: Site Administrator <>
-  To: daniel@domain.tld
   ...Super Bowl XLII...Drug-resistant flu rising, says WHO...
   To: mailman@domain.tld
   ...Drug-resistant flu rising, says WHO...
@@ -1853,7 +1877,7 @@ For the default HTMLComposer we can specify sender name and address
 as well as reply-to address.
 
   >>> browser.open(portal.absolute_url() +
-  ...  	'/portal_newsletters/channels/my-other-channel')
+  ...   '/portal_newsletters/channels/my-other-channel')
   >>> from_name = browser.getControl(name="composers.html.widgets.from_name")
   >>> from_addr = browser.getControl(name="composers.html.widgets.from_address")
   >>> replyto = browser.getControl(name="composers.html.widgets.replyto_address")
@@ -1876,7 +1900,7 @@ Let's set some values.
 And see that they've stuck.
 
   >>> browser.open(portal.absolute_url() +
-  ...  	'/portal_newsletters/channels/my-other-channel')
+  ...   '/portal_newsletters/channels/my-other-channel')
   >>> browser.getControl(name="composers.html.widgets.from_name").value
   'Portal Master'
   >>> browser.getControl(name="composers.html.widgets.from_address").value
@@ -1928,7 +1952,7 @@ If a channel has more formats, they will of course all be editable
 from this page.
 
   >>> browser.open(portal.absolute_url() +
-  ...  	'/portal_newsletters/channels/my-other-channel')
+  ...   '/portal_newsletters/channels/my-other-channel')
   >>> 'composers.html.widgets.from_name' in browser.contents
   True
   >>> 'composers.text.widgets.from_name' in browser.contents
@@ -1937,7 +1961,7 @@ from this page.
   >>> channel.composers['text'] = HTMLComposer()
 
   >>> browser.open(portal.absolute_url() +
-  ...  	'/portal_newsletters/channels/my-other-channel')
+  ...   '/portal_newsletters/channels/my-other-channel')
   >>> 'composers.html.widgets.from_name' in browser.contents
   True
   >>> 'composers.text.widgets.from_name' in browser.contents

--- a/collective/dancing/composer.py
+++ b/collective/dancing/composer.py
@@ -586,9 +586,11 @@ class Dispatch(collective.singing.mail.Dispatch):
 
     def __call__(self):
         msg = self.message
-        delivery = component.getUtility(Products.CMFPlone.interfaces.IPloneSiteRoot).MailHost
+        delivery = component.getUtility(
+            Products.CMFPlone.interfaces.IPloneSiteRoot).MailHost
         try:
-            delivery.send(msg.as_string(), mfrom=msg['From'], mto=self._split(msg['To']))
+            delivery.send(msg.as_string(), mfrom=msg['From'],
+                mto=self._split(msg['To']))
         except Exception, e:
             # TODO: log
             return u'error', traceback.format_exc(e)

--- a/collective/dancing/configure.zcml
+++ b/collective/dancing/configure.zcml
@@ -153,7 +153,7 @@
            provides=".interfaces.IFullFormatter"
            name="html" />
 
-  <adapter factory="collective.singing.mail.Dispatch" />
+  <adapter factory="collective.dancing.composer.Dispatch" />
 
   <!-- Transforms -->
   <adapter factory=".transform.URL"

--- a/collective/dancing/portlets.txt
+++ b/collective/dancing/portlets.txt
@@ -17,8 +17,14 @@ Test Setup
 
 We want messages to be printed out instead of sending them:
 
-  >>> from collective.dancing.tests import setup_testing_maildelivery
-  >>> delivery = setup_testing_maildelivery()
+  >>> from collective.dancing.tests import MockMailHost
+  >>> self.portal._delObject('MailHost')
+  >>> mail_host = MockMailHost('MailHost')
+  >>> self.portal._setObject('MailHost', mail_host)
+  'MailHost'
+  >>> self.portal.MailHost
+  <MockMailHost at /plone/>
+  >>> delivery = self.portal.MailHost
 
 First off, let's edit the default collector, delete the default Collection and add two optional blocks. These can later be set from our portlet.
 


### PR DESCRIPTION
Issue #5 suggests updating collective.dancing to use Plone's MailHost by default.

MailHost on Plone >= 4.0 can be configured to use queues which allows suitable performance to be configured TTW without needing to add custom ZCML for mailers and mail delivery.

It also allows collective.dancing to work nicely with things like PrintingMailHost and MultiMailHost.

This patch provides and registers a plone specific dispatcher.