### PR TITLE
deactivate diazo for rendering the newsletter preview

### DIFF
--- a/collective/dancing/browser/preview.py
+++ b/collective/dancing/browser/preview.py
@@ -43,6 +43,9 @@ class PreviewNewsletterView(BrowserView):
 
     def __call__(self, name=None, include_collector_items=False, override_vars=None):
 
+        # deactivate diazo - we style our newsletters without it
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
+
         if override_vars is None:
             override_vars = '{}'
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,8 +1,14 @@
 Changelog
 =========
 
+dev (unreleased)
+----------------
+
+- Disable diazo for `@@preview-newsletter.html`
+  [fRiSi]
+
 1.0 (2015-05-11)
--------------------
+----------------
 
 - Don't try to patch ATTopic if ``plone.app.collection`` is available.
   [saily]


### PR DESCRIPTION
i think this makes sense for all users as diazo will also not be used when rendering the message in the composer.
if you're ok with that please merge and remove the branch