### PR TITLE
Fix html generation in preview.pt

### DIFF
--- a/collective/dancing/browser/preview.pt
+++ b/collective/dancing/browser/preview.pt
@@ -10,6 +10,6 @@
     </title>
   </head>
 
-  <body tal:content="structure options/content" />
+  <body tal:replace="structure options/content" />
 
 </html>

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 dev (unreleased)
 ----------------
 
+- Fix html generation in `preview.pt`. Now it generates only 1 <body> tag.
+  This was a problem with plone.protect's transform.
+  [cekk]
+
 - Allow to confirm a subscription for multiple channels (fixes #8)
   [fRiSi]
 
@@ -12,6 +16,7 @@ dev (unreleased)
 
 - Disable CSRF protection on `tick_and_dispatch` request (fixes #24)
   [ivanteoh]
+
 
 1.0 (2015-05-11)
 ----------------


### PR DESCRIPTION
I have this problem with a newsletter preview on a site with the new plone4.csrf patch.

This solves the problem, because the body is already present on options/content returned html.