### PR TITLE
Respect subscribeable

### DIFF
--- a/collective/dancing/browser/subscribe.pt
+++ b/collective/dancing/browser/subscribe.pt
@@ -6,15 +6,22 @@
       i18n:domain="collective.dancing"
       tal:omit-tag="">
 
-<div>
-  <p tal:content="structure view/send_secret_link" />
-</div>
+<tal:subscribeable condition="context/subscribeable">
+  <div>
+    <p tal:content="structure view/send_secret_link" />
+  </div>
 
-<div tal:define="subscribeform view/subscribeform"
-     tal:condition="subscribeform"
-     id="subscription-subscribeform">
-  <div tal:content="structure subscribeform"></div>
-</div>
+  <div tal:define="subscribeform view/subscribeform"
+       tal:condition="subscribeform"
+       id="subscription-subscribeform">
+    <div tal:content="structure subscribeform"></div>
+  </div>
+</tal:subscribeable>
 
+<tal:notsubscribeable condition="not: context/subscribeable">
+
+<p i18n:translate="">The Mailing-list '<span i18n:name="channel" tal:content="context/Title">Channel</span>' is not open for subscriptions.</p>
+
+</tal:notsubscribeable>
 
 </html>

--- a/collective/dancing/locales/bg/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/bg/LC_MESSAGES/collective.dancing.po
@@ -16,933 +16,1015 @@ msgstr ""
 "X-Poedit-Language: Bulgarian\n"
 "X-Poedit-Country: BULGARIA\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr ""
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr ""
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Вече сте абонирани?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Прилагане"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Прилагане на промените"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr ""
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr ""
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr ""
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Промяна на вашия абонамент в ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Изчистване на приключилите задачи"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Изчистване на съобщенията в опашката"
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Щракнете тук за промяна на вашия абонамент в ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr ""
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Щракнете тук за премахване на абонамента."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Потвърдете вашия абонамент в  ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Потвърдете вашия абонамент"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Дата на изпълнение"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr ""
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Изтегляне"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "E-mail адрес"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Редактиране"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Редактиране ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Редактиране на ${selector} за ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 #, fuzzy
 msgid "Edit Mailing-list ${channel}"
 msgstr "Редактиране на канал ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Редактиране на съществуващите абонаменти"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr ""
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr ""
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Завършили задачи"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr ""
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "От адрес"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "От име"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr ""
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr ""
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Беше ви изпратена информация как да потвърдите вашия абонамент."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Позицията беше добавена успешно."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Позицията беше изтрита успешно."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Позицията беше преместена успешно."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Позиции"
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Име на задачата"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Последна промяна"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Управление или добавяне на абонаменти."
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Управление на вашите абонаменти"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Тема на съобщението"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Съобщенията бяха добавени в опашката успешно."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Съобщенията бяха изпратени успешно"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Съобщения чакащи да бъдат изпратени"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Съобщения с грешки"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr ""
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Преместване на блока надолу"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Преместване на блока нагоре"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Моите абонаменти"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Нови съобщения"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Бюлетин"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr ""
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Само някои от вашите промени бяха записани"
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Чакащи задачи"
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Моля потвърдете вашия абонамент"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Моля въведете дата."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Моля изберете позиции, които да бъдат изтрити."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Моля изберете позиции с нови съобщения които да бъдат изчистени."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr ""
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Преглед"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Продължаване"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Изпълнение на задачите"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Премахване на блок"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Премахване на записи"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Премахване на старите съобщения"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Повтаряне на съобщенията"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Текст"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Запис"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Търсене"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Търсене на абонати"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Секции"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Преглед на бюлетина"
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Изпращане"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Изпращане на ${item} като бюлетин"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Изпращане като бюлетин"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr ""
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Изпращане на съобщенията в опашката веднага"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Изпратени съобщения"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr ""
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr ""
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Статус"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Абониране"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Абониране директно от портлета"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Абониране за ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Абонати"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Абонаменти"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr ""
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr ""
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr ""
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Изглежда има грешка в информацията, която сте въвели."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Бяха открити грешки."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr ""
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Заглавие"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Заглавие на портлета"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "За да потвърдите вашия абонамент за ${channel}, моля щракнете тук: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr ""
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr ""
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Веднага"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Тип"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Неизвестен"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Прекратяване на абонамента"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Отказване от бюлетина"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr ""
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr ""
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr ""
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Качване"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Качване на списък с абонати."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Вие вече сте абониран(а). Попълнете формата в края на тази страница и ще получите връзка, от която може да промените вашия абонамент."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Вие имате абонамент за тези канали:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Вие нямате абонамент за този канал."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Вие може да се абонирате за тези бюлетини:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Вие потвърдихте успешно вашия абонамент."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Може да използвате променливи, като ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Вашия абонамент премина успешно."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Вашия абонамент беше закрит."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Вие получихте този e-mail защото бяхте абониран(а) за ${channel} бюлетин."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Вашия e-mail адрес е невалиден"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Вашия абонамент не е познат за нас."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Вашия абонамент беше обновен."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr ""
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr ""
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr ""
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Управление на канал"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Управляние на колектор"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Статистика"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/ca/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/ca/LC_MESSAGES/collective.dancing.po
@@ -17,893 +17,975 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #. Default: "channel"
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "opcions de ${channel}"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
 #. Default: ""
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} missatges en cua"
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Afegeix"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 #, fuzzy
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Afegir Portlet de subscripció a canal"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Adreça a la qual enviar la vista prèvia"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "S'han esborrat tots els missatges enviats i fallits."
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Ja estàs subscrit?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Aplica"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Aplica els canvis"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Tornar a portlets"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Baix hi ha una llista dels butlletins de notícies que oferim. Si ja estàs subscrit a algun d'ells pots omplir el formulari que apareix al final d'aquest pàgina perquè se t'envie un enllaç des del qual pots editar les teues subscripcions."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Salutacions cordials"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 #, fuzzy
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Canvia les teues subscripcions en ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Fes clic ací per gestionar les teues subscripcions a ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Fes clic ací per seleccionar que les opcions del col·lector s'activen automàticament quan algú se subscriu des d'aquest portlet."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Fes clic ací per mostrar el peu del portlet."
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Fes clic ací per donar-te de baixa."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
 #. Default: "channel-title"
-#: ./composer.py:357
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Confirma la teua subscripció a ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Confirmant la teua subscripció"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Descripció del portlet"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr ""
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Adreça de correu electrònic"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr ""
 
 #. Default: ""
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Edita ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
 #. Default: "channel"
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 #, fuzzy
 msgid "Edit Mailing-list ${channel}"
 msgstr "Edita el canal ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 #, fuzzy
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Edita el portlet de subscripció al canal"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Edita les subscripcions existents"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Missatges fallits"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 #, fuzzy
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Troba el canal al qual vols permetre les subscripcions directes"
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Text del peu"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "Correu electrònic HTML"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Inclou element del col·lector"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Se t'ha enviat informació sobre com confirmar la teua subscripció."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "S'ha afegit l'element."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "S'ha esborrat l'element."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "S'ha mogut l'element."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr ""
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Darrer canvi"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Gestiona les teues subscripcions"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Missatges enviats amb èxit"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Missatges esperant ser enviats"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Missatges amb errors"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Missatges amb errors en la cua de reintent"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Meneja el bloc cap avall."
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Meneja el bloc cap amunt."
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Les meues subscripcions"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Missatges nous"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Newsletter"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "No hi ha missatges en cua."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Per favor, confirma la teua subscripció."
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr ""
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Descripció del portlet"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Capçalera del portlet"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Procedeix"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Eliminar el bloc."
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr ""
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Missatges reintentats"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Text enriquit"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr ""
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Seccions"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Envia"
 
 #. Default: ""
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Envia ${item} com a butlletí de notícies"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Envia vista prèvia"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Missatges enviats"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Deus estar subscrit a una de les nostres llistes; per favor, utilitza aquest formulari perquè t'enviem un enllaç a la teua pàgina personal de subscripció:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Mostra peu"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Mostra vista prèvia"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Configuració de Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Subscriu-te"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Subscriure's directament des del portlet"
 
 #. Default: "channel"
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Subscriu-te a ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 #, fuzzy
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Text del peu - si s'omet s'utilitzarà el títol del canal"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 #, fuzzy
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Canal al qual permetre la subscripció."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 #, fuzzy
 msgid "The mailing-list to send this through"
 msgstr "Canal a través del qual enviar açò."
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Sembla que hi ha un error en la informació que has introduït."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Hi ha hagut alguns errors."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Açò només es requereix si fas clic en el botó 'Enviar vista prèvia' que apareix baix."
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 #, fuzzy
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Aquest portlet permet que un visitant es subscriga a un canal de butlletí de notícies específic."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Títol"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Títol del portlet tal i com es mostra"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Per confirmar les teues subscripcions a ${channel}, per favor fes clic ací: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Total de missatges enviats"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Nombre total de missatges enviats amb èxit"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Dispara ara"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Tipus"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Dóna de baixa la subscripció"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Dona't de baixa del butlletí de notícies"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Puja a Administració de col·lectors"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Puja a la Configuració de Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Puja a Configuració del lloc"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Ja estàs suscrit. Ompli el formulari que apareix més avall perquè t'envien un enllaç des del qual poder modificar la teua subscripció."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Estàs subscrit a aquests butlletins:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "No estàs subscrit a aquest canal."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Pots subscriure't a aquests butlletins:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Has confirmat les teues subscripcions correctament."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "T'has subscrit correctament."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "T'has donat de baixa correctament."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Has rebut aquest correu electrònic perquè t'has subscrit al butlletí de notícies ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "L'adreça de correu electrònic és incorrecta."
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "No coneixem la teua subscripció."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "La teua subscripció ha estat actualitzada."
 
@@ -911,7 +993,7 @@ msgstr "La teua subscripció ha estat actualitzada."
 # "        itself.  Rather, it provides a number of components to configure\n"
 # "        and work with.  It is also the container of subscriptions to it."
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 #, fuzzy
 msgid "description_channel_administration"
 msgstr "Un canal és un element essencial per la configuració. No fa res per si mateix. Proporciona una sèrie de components amb els quals treballar que es poden configurar. També és el contenidor que enregistra les seues pròpies subscripcions."
@@ -919,52 +1001,52 @@ msgstr "Un canal és un element essencial per la configuració. No fa res per si
 # "Collectors are useful for automatic newsletters.  They are\n"
 # "      responsible for assembling a list of items for publishing."
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 #, fuzzy
 msgid "description_collector_administration"
 msgstr "Els col·lectors són útils per als butlletins de notícies automàtics. Serveixen per arreplegar una llista d'elements per a publicació."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Mostra estadístiques del butlletí"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Administració dels canals"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Administració de col·lectors"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Estadístiques"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/collective.dancing.pot
+++ b/collective/dancing/locales/collective.dancing.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-05-13 07:11+0000\n"
+"POT-Creation-Date: 2017-02-27 15:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,923 +14,1005 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr ""
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr ""
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr ""
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr ""
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr ""
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr ""
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr ""
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr ""
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr ""
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr ""
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr ""
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr ""
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr ""
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr ""
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr ""
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr ""
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr ""
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr ""
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr ""
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr ""
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr ""
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr ""
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr ""
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr ""
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr ""
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr ""
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr ""
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr ""
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr ""
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr ""
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr ""
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr ""
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr ""
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr ""
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr ""
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr ""
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr ""
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr ""
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr ""
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr ""
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr ""
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr ""
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr ""
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr ""
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr ""
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr ""
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr ""
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr ""
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr ""
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr ""
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr ""
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr ""
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr ""
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:294
+#: ../browser/subscribe.py:301
 msgid "There seems to be an error with
                 the information you entered."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr ""
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr ""
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr ""
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr ""
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr ""
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr ""
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr ""
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr ""
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr ""
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr ""
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr ""
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr ""
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr ""
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:239
+#: ../browser/subscribe.py:246
 msgid "You are already subscribed.
                                   Fill out the form at the end of this page
                                   to be sent a link from where you can
                                   edit your subscription."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr ""
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr ""
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr ""
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr ""
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr ""
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr ""
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr ""
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr ""
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr ""
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr ""
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr ""
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr ""
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr ""
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/collective.dancing.pot
+++ b/collective/dancing/locales/collective.dancing.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-27 15:29+0000\n"
+"POT-Creation-Date: 2017-02-27 16:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/collective/dancing/locales/cs/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/cs/LC_MESSAGES/collective.dancing.po
@@ -16,892 +16,974 @@ msgstr ""
 "Generated-By: zope/app/translation_files/extract.py\n"
 
 #. Default: "channel"
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "Nastavení ${channel}"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} nepodporuje plánování."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "Počet úspěšně aktualizovaných přihlášení: ${numberadded}"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "Počet úspěšně aktualizovaných přihlášení: ${numberadded}, počet zrušených: ${numberremoved}"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "Počet úspěšně aktualizovaných přihlášení: ${numberadded}, počet zrušených: ${numberremoved}. Počet těch, které nemohly být přidány: ${numbernotadded}  (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
 #. Default: ""
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "Počet zpráv ve frontě: ${number}."
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "Počet zpráv přidaných do fronty: ${num}."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "Počet odeslaných zpráv: ${sent}, počet neodeslaných: ${failed}."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Přidat"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 #, fuzzy
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Přidat portlet přihlášení"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Adresa na kterou se má odeslat náhled"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Všechny ukončené úlohy byly vymazány."
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Všechny čekající úlohy byly zpracovány."
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Všechny odeslané a neúspěšně odeslané zprávy byly vymazány"
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Existující přihlášení?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "V tomto odeslání přidat i automaticky vybraný obsah."
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Použít"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Použít změny"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Zpět na správu portletů"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Níže je uvedený seznam zpravodajů které nabízíme. Pokud jste již k některému z nich přihlášen(a), vyplňte prosím formulář na konci stránky a bude vám odeslán email s informacemi, které vám umožní spravovat vaše přihlášení."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Děkujeme"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS styl"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Nastavení vašeho přihlášení na ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Vymazat ukončené úlohy"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Vymazat zprávy ve frontě"
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Klepněte zde pro nastavení a správu vašich odběrů na ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Zaškrtněte, pokud chcete v případě přihlášení z portletu zpřístupnit nastavení nástroje pro sběr dat."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Zaškrtněte, pokud chcete zonrazit patičku portletu."
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Pro odhlášení klepněte zde."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
 #. Default: "channel-title"
-#: ./composer.py:357
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Potvrďte prosím vaše přihlášení k ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Potvrzení přihlášení"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Datym vykonání"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Popis portletu"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Zobrazí formulář, pomocí kterého můžete odeslat obsah této stránky jako zpravodaj."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Stáhnout"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "E-mail adresa"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Upravit"
 
 #. Default: ""
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Nastavení ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
 #. Default: "channel"
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 #, fuzzy
 msgid "Edit Mailing-list ${channel}"
 msgstr "Úprava kanálu ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 #, fuzzy
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Nastavení portletu pro správu přihlášení"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Nastavení existujících přihlášení"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Neúspěšně odesláno"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 #, fuzzy
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Vyhledejte prosím kanál, ke kterému chcete zpřístupnit přihlášení."
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Patička"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML E-mail"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Včetně položek příslušného nástroje sběru dat"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Byly vám odeslány informace nutné k dokončení vašeho přihlášení."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Položka byla přidána."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Položka byla odebrána."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Položka byla přesunuta."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Položky"
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Název úlohy"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Poslední změna"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Správa odběrů"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Předmět zprávy"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Zprávy k odeslání."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Úspěšně odesláno"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Zprávy čekající na odeslání"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Zprávy s chybami"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Zpráv s chybami v opravné frontě"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Přesunout dolů"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Přesunout nahoru"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Mé přihlášení"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Nové zprávy"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Zpravodaj"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Žádné položky nebyly nalezeny."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Ve frontě nejsou žádné zprávy."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Čekajícé úlohy"
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Potvrďte prosím vaše přihlášení k odběru"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Zadejte prosím datum."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Vyberte prosím položky, které chcete vymazat."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Popis portletu"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Nadpis portletu"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Náhled"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Odeslat"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Zpracovat úlohy"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Odebrat"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Odebrat položky"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Vymazat staré zprávy"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Opakované zprávy"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Formátovaný text"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Uložit"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Plánovaný čas"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Vyhledat"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Sekce"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Odeslat"
 
 #. Default: ""
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Odeslat ${item} jako zpravodaj"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Odeslat jako newsletter"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Odeslat náhled"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Ihned odeslat zprávy ve frontě"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Odeslané zprávy"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Pravděpodobně již existuje vaše přihlášení k některému ze zpravodajů. Použijte prosím následující formulář a bude vám odeslán email s odkazem na vaši stránku s nastavením přihlášení."
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Zobrazit patičku"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Zobrazit náhled"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Nastavení produktu Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Stav"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Přihlásit"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Přihlásit se přímo z portletu"
 
 #. Default: "channel"
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Přihlášení k ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 #, fuzzy
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Text v patičce portletu. Není-li vyplněno, bude moužit nadpis kanálu."
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 #, fuzzy
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Kanál, ke kterému se uživatel bude přihlašovat."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 #, fuzzy
 msgid "The mailing-list to send this through"
 msgstr "Kanál, přes který se má položka odeslat"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Vámi zadané údaje nesouhlasí."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Opravte prosím vyznačené chyby."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Vyplňte pouze v případě, že chcete použít funkci \"Odeslat náhled\" níže."
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 #, fuzzy
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Tento portlet umožňuje návštěvníkům přihlásit se k odběru informací určitého kanálu."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Nadpis"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Nadpis portletu"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Pro potvrzení přihlášení kanálu ${channel} klepněte prosím zde: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Celkový počet odeslaných zpráv"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Celkový počet úspěšně odeslaných zpráv"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Spustit teď"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Typ"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Odhlásit"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Odhlásit z odběru zpravodaje"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Zpět na správu nástrojů sběru dat"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Zpet na nastavení produktu Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Zpět na nastavení portálu"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Takové přihlášení již existuje. Klepněte prosím na odkaz na konci této stránky a bude vám odeslána zpráva, ve které najdete odkaz na nastavení vašeho přihlášení."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "V současné době jste přihlášen(a) k těmto zpravodajům:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Nejste přihlášen(a) k tomuto kanálu."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Můžete se přihlást k těmto zpravodajům:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Vaše přihlášení bylo úspěšně potvrzeno."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Přihlášení proběhlo úspěšně."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Odhlášení úspěšně provedeno."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Tento email dostáváte, protože jste registrován(a) k odběru informací ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Vaše e-mail adresa není platná"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Takové přihlášení neexistuje."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Vaše přihlášení bylo aktualizováno."
 
@@ -909,7 +991,7 @@ msgstr "Vaše přihlášení bylo aktualizováno."
 # "        itself.  Rather, it provides a number of components to configure\n"
 # "        and work with.  It is also the container of subscriptions to it."
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 #, fuzzy
 msgid "description_channel_administration"
 msgstr "Kanál je konfigurační uzel. Sám o sobě nedělá nic, ale poskytuje sadu komponent, které je možné konfigurovat a pracovat s nimi. Zároveň spravuje i přihlášení k odběru uvedených informací."
@@ -917,52 +999,52 @@ msgstr "Kanál je konfigurační uzel. Sám o sobě nedělá nic, ale poskytuje 
 # "Collectors are useful for automatic newsletters.  They are\n"
 # "      responsible for assembling a list of items for publishing."
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 #, fuzzy
 msgid "description_collector_administration"
 msgstr "Nástroj pro sběr dat jse vhodný pro automatické odesílání. Zajišťuje sběr informací, které budou odeslány."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Zobrazení statistik"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Správa kanálů"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Správa nástroje pro sběr dat"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Statistiky"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/da/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/da/LC_MESSAGES/collective.dancing.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -18,936 +18,1018 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.dancing\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "${channel} indstillinger"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} understøtter ikke skedulering."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} abonnementer opdateret!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} abonnementer opdateret, ${numberremoved} fjernet!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} abonnementer opdateret. ${numberremoved} fjernet. ${numbernotadded} kunne ikke tilføjes. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberremoved} abonnementer blev fjernet."
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} beskeder lagt i kø"
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} besked(er) lagt i kø."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} besked(er) sendt, ${failed} fejl."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Tilføj"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Tilføj abonneringsportlet"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr "Tilføj til ${title}"
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr "Tilføj og eller rediger postlister, der indsamler og udsender information fra dit site, til tilmeldte abonnenter, på fastlagte tidspunkter."
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Adresse, der modtager forhåndsvisning"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Alle afsluttede job fjernet"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr "Alle job blev fjernet"
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Alle job behandlet"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Alle "
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Er du allerede abonnent?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Inkluder automatisk indsamlet indhold i denne udsendelse"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Udfør"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Udfør ændringer"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Tilbage til portlets"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Nedenfor ser du en liste over de nyhedsbreve vi tilbyder. Abonnerer du allerede på en eller flere af duisse, skal du udfylde formularen nederst på siden. Du vil derefter få tilsendt et link til en side, hvor du kan redigere dine tilmeldinger."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Venlig hilsen"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS Skriftsnitark"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV indeholder en 'header-række'"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "CSV adskilletegn"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr "Din identitet kan ikke fastslås. Kontroller venligst din URL."
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "${site_title}: Rediger dine tilmeldinger"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Fjern afsluttede job"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr "Fjern alle job"
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Fjern job i køen"
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Klik på nedenstående link for at redigere dine tilmeldinger på ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Klik her for at vælge de abonnements-mulighed, som abonnenten automatisk skal have slået til, når han abonnerer fra denne portlet."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Klik her for at vise portlettens footer"
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Klik her for at framelde dig"
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr "Dynamisk liste til ${title}"
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr "Dynamisk liste: ${title}"
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr "Indsamlerblok"
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr "Indsamlerblok: ${title}"
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Composer til formatet : ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Composere"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Bekræft din tilmelding til ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Bekræfter din tilmelding"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr "Udvælgelse af indhold"
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Selvvalgt Emne"
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Udførselsdato"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Beskrivelse af portletten"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Viser en formular, der giver dig mulighed for at sende indholdsobjektet som et nyhedsbrev."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Download"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Email-adresse"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Rediger"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Rediger ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Rediger ${selector} til ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr "Rediger postlisten ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Rediger Abonneringsportlet"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Rediger eksisterende abonnementer"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr "Redigér den Dynamiske liste"
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Rediger composerens egenskaber."
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "Rediger postlistens egenskaber."
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Indtast en Emne-linie til nyhedsbrevet her. Lad feltet være blankt for at benytte standard emnet for det valgte indhold og den valgte postliste."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Indtast søgeord"
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Fejl under importen. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Beskeder med fejl"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Filen har et ikke-understøttet format."
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Der bblev ikke angivet en fil."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Udfyld denne formular for at få adgang til at redigere dine abonnementer. Du vil få tilsendt en e-mail med et link til en side hvor du kan fra- og tilmelde dig alle de nyhedsbreve sitet tilbyder."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Udfyld nedenstående formular for at abonnere på ${channel}. Bemærk at dette gælder nye abonnenter. Klik her forat ${link_start}redigere dine eksisterende abonnementer${link_end}."
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Find den postliste, du vil gøre direkte abonnerbar"
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Afsluttede job"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Footertekst"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Afsenderadresse"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Afsenderens navn"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Generer"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML email"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Header tekst"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Medtag automatisk indsamlet indhold"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Bekræft venligst din tilmelding i tilsendt e-mail."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Er nu tilføjet"
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Er nu slettet"
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Er flyttet"
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Emner"
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Jobtitel"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Seneste ændring"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr "Seneste nyheder"
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Rediger eller tilføj abonnementer."
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Rediger tilmeldinger"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Beskedens emne"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Beskeder lagt i afsendelseskøen."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Beskederne er nu sendt ud"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Beskeder der venter på at blive udsendt"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Beskeder med fejl"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Beskeder med fejl som venter på et nyt forsøg"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Flyt blok ned"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Flyt blok op"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Mine abonnementer"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Nye beskeder"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Nyhedsbrev"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr "Postlister"
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Der blev ikke fundet noget indhold."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Ingen beskeder i kø."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr "Fjern kun abonnenter fra denne liste."
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Kun nogle af dine ændringer blev gemt"
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Job i udsendelseskøen"
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Bekræft din tilmelding"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Udfyld venligst en dato."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Vælg venligst indhold der skal fjernes."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Vælg venligst kanaler med nye beskeder der skal fjernes."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr "Vælg den postliste du vil udsende beskeder i køen fra."
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Beskrivelse af portlet"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Portlet overskrift"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Forhåndsvisning"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Fortsæt"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Behandl job"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "Tøm listen før import"
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "Tøm listen."
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Slet blok"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Fjern valgte"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Fjern gamle beskeder"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "Fjern abonnenter i listen."
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Reply-to adresse"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Prøv-igen beskeder"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Wysiwyg-tekst"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr "WYSIWYG-tekst: ${title}"
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Gem"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Skeduler udsendelse"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Udsendelsestidspunkt"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Søg"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Søg blandt abonnenter"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Sektioner"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Se en forhåndsvisning af nyhedsbrevet i browseren."
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Vælg denne mulighed hvis du vil benytte csv-filens 'header-række' til udvælgelse af variable. 'Header-rækken' skal indeholde et felt med navnet 'email'."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Udsend"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Send ${item} som nyhedsbrev"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "Send '${context}' igennem ${channel}."
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Send som nyhedsbrev"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Send forhåndsvisning"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Send beskeder i køen nu"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Beskeder nu sendt"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Hvis du allerede abonnerer til en af vores nyhedsbreve, kan du bruge denne formular til at få tilsendt et link til en side, hvor du kan ændre dit abonnement:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Vis footer"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Vis forhåndsvisning"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Administration af nyhedsbreve"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Standard kanal"
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Status"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Abonner"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Abonner direkte fra portlet"
 
 #. Default: "channel"
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Abonner på ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Abonnenter"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Abonnenter eksporteret."
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Abonnementer"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Beskeder i udsendelseskøerne for de valgt postlister blev sletter."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Gamle beskeder i de valgte postlister blev slettet."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Skeduleret udsendelse oprettet."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr "Skabelon"
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Tekst i footer - hvis udeladt bruges postlistens navn"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Tekst der vil optræde i begyndelse af hver udsendt besked. Du kan benytte flere variable her, f.eks. ${subject}."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Tekst der vil optræde i slutningen af hver udsendt besked."
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "Indtast venligst den adresse, forhåndsvisningen skal sendes til."
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "Det adskillelsestegn der benyttes i CSV-filen. (Som regel ',' eller ';'.)"
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "'Fra'-adressen, som den vil optræde i beskeder sent af denne composer."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Den postliste, der skal kunne abonneres på."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "Den postliste, der skal sendes gennem"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "'reply-to'-adressen, som den vil optræde i beskeder sent af denne composer."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Afsendernavnet, som det vil optræde i beskeder udsendt af denne postliste."
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "Skriftsnitarket vil blive brugt på dokumentet."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "Den skabelon der skal benyttes."
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Du har indtastet en fejl."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Der opstod fejl"
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Dette er kun påkrævetm, hvis du klikker 'Skeduler udsendelse' nedenfor"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Dette er kun nødvendigt hvis du klikker på 'Send forhåndsvisning' herunder"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Denne portlet gør det muligt for en besøgende at abonnere på en specifik postliste."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Titel"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Titel på den renderede portlet"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Du kan bekræfte din tilmelding til ${channel} ved at klikke her: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Udsendt i alt"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Udsendt i alt (med held)"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Send nu"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Type"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Afmeld"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Afmeld nyhedsbrev"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Til administration af indsamlere"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr "Op til Administration af postlister"
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Til nyhedsbrevs-administration"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Til Plones kontrolpanel"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Upload"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Her kan du uploade en CSV fil med abonnenter. Abonnenter der allerede findes i databasen vil blive overskrevet. Hver linie bør indeholde: ${columns}."
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Upload liste med abonnenter."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "Benyt abonnementsside med kun en formular"
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "Benyt abonnementsside med kun en formular hvis det er muligt."
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Du abonnerer allerede på dette nyhedsbrev. Klik her for at ${link_start}redigere dine abonnementer${link_end}."
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Du abonnerer allerede. Udfyld formularen nederst på siden for at få tilsendt et link, hvorfra du kan redigere dit abonnement."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Rediger dine tilmeldinger:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Du abonnerer ikke på denne postliste."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr "Du kan ikke tilføj når du har valgt kun at fjerne abonnenter."
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Tilmeld dig flere nyhedsbreve:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Din bekræftelse af abonnementet gik igennem."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Du kan benytte en række variable her, f.eks. ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Dit abonnement er nu tilmeldt."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Du er nu afmeldt."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr "Du er nu frameldt alle nyhedsbreve."
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Du modtager denne email, fordi du er oprettet som abonnent på ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Din email-adresse er ugyldig"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "Din e-mail-adresse er allerede tilmeldt. Klik på linket nedenfor for at redigere dine tilmeldinger."
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Dit abonnement findes ikke i systemet."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Dine abonnementændringer blev gemt"
 
 # Rather, it provides a number of components to configure and work with.
 # It is also the container of subscriptions to it."
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 #, fuzzy
 msgid "description_channel_administration"
 msgstr "En postliste er en sammenføjning af de elementer der udgør en nyhedsbrevskonfiguration - den gør intet i sig selv, men giver mulighed for at konfigurere en række delkomponenenter. Den indeholder samtidig en liste over de tilmeldte abonnenter."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 #, fuzzy
 msgid "description_collector_administration"
 msgstr "Indsamlere er nyttige til automatisk udsendte nyhedsbreve. De står for indsamling af objeketer, der skal udsendes."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "Her kan du ændre nogle aspekter af nyhedsbrevenes opførsel."
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Se statistik for nyhedsbreve"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Administration af kanaler"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Administration af indsamlere"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "Globale indstillinger"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr "(påkrævet)"
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Statistik"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr "Påkrævet"
 

--- a/collective/dancing/locales/de/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/de/LC_MESSAGES/collective.dancing.po
@@ -1,10 +1,11 @@
+# Harald Friessnegger <harald@webmeisterei.com>, 2017.
 msgid ""
 msgstr ""
 "Project-Id-Version: Singing & Dancing\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"PO-Revision-Date: \n"
-"Last-Translator: Daniel Widerin <daniel.widerin@kombinat.at>\n"
-"Language-Team: David Picó Vila <david.pico.vila@gmail.com>\n"
+"PO-Revision-Date: 2017-02-27 16:35+0100\n"
+"Last-Translator: Harald Friessnegger <harald@webmeisterei.com>\n"
+"Language-Team: German <kde-i18n-de@kde.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -17,6 +18,8 @@ msgstr ""
 "X-Poedit-Language: German\n"
 "X-Poedit-Country: AUSTRIA\n"
 "X-Poedit-SourceCharset: utf-8\n"
+"Language: de_DE\n"
+"X-Generator: Lokalize 2.0\n"
 
 #: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
@@ -748,7 +751,7 @@ msgstr "Dieser Text wird automatisch am Ende jeder Nachricht angezeigt."
 
 #: ../browser/subscribe.pt:23
 msgid "The Mailing-list '${channel}' is not open for subscriptions."
-msgstr ""
+msgstr "Derzeit ist die Anmeldung für den Newsletter '${channel}' nicht möglich."
 
 #: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."

--- a/collective/dancing/locales/de/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/de/LC_MESSAGES/collective.dancing.po
@@ -18,911 +18,993 @@ msgstr ""
 "X-Poedit-Country: AUSTRIA\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "${channel} Einstellungen"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} unterstützt keinen Zeitplan!"
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} Anmeldungen erfolgreich aktualisiert."
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} Anmeldungen erfolgreich aktualisiert, ${numberremoved} entfernt!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} Anmeldungen erfolgreich aktualisiert. ${numbernotadded} Anmeldung(en) konnte(n) nicht hinzugefügt werden. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberadded} Anmeldungen erfolgreich entfernt."
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} Nachrichten auf der Warteliste"
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} Nachricht(en) auf der Warteliste"
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} Nachricht(en) gesendet, ${failed} fehlgeschlagen."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Portlet für direkte Anmeldung zu einem Newsletter hinzufügen"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Vorschau an diese E-Mail Adresse senden"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Alle erledigten Aufgaben gelöscht"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Alle ausständigen Aufgaben durchgeführt"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Alle gesendeten und fehlgeschlagenen Messages gelöscht."
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Sind Sie bereits angemeldet?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Sollen automatisch gesammelte Inhalte an diese Aussendung angehängt werden?"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Übernehmen"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Änderungen übernehmen"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Zurück zur Portletverwaltung"
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Hier sehen Sie eine Liste aller Newsletter die wir anbieten. Falls Sie bereits zu einem dieser Newsletter angemeldet sind können Sie das untenstehende Formular ausfüllen und wir senden Ihnen einen Link zu, um Ihre Abonnements zu bearbeiten."
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "mit freundlichen Grüßen"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV beinhaltet eine Kopfzeile"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "CSV Trennzeichen"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Ändern Sie Ihre Abonnements für ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Erledigte Aufgaben entfernen"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Wartende Nachrichten löschen"
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Klicken Sie auf folgenden Link um Ihre Abonnements für ${site_title} zu verwalten."
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Bestimmen Sie, ob ein direktes Anmelden über das Portlet möglich sein soll - falls nicht werden Sie zum Anmeldeformular weitergeleitet und die eingegebenen Daten werden dort eingetragen."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Bestimmen Sie, ob die Fusszeile des Portlets angezeigt werden soll."
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Falls Sie in Zukunft auf diesen Newsletter verzichten möchten - Klicken Sie bitte hier."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Vorlage für folgendes Format: ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Vorlagen"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Anmeldung zum Newsletter ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Anmeldung bestätigt"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Eigener Betreff"
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Ausführungsdatum"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Geben Sie eine kurze Beschreibung des Portlets an."
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Zeigt ein Formular an, welches Sie diesen Inhalt als Newsletter versenden lässt."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Herunterladen"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "E-Mail Adresse"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "${collector} bearbeiten"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "${selector} von ${channel} bearbeiten"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Portlet für direkte Anmeldung zu einem Newsletter bearbeiten"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Bestehende Abonnements bearbeiten"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Eigenschaften der Vorlage bearbeiten"
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "Eigenschaften des Newsletters bearbeiten"
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Optional kann der E-Mail Betreff geändert werden. Lassen Sie dieses Feld leer um den Standardbetreff zu verwenden."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Geben Sie einen Suchbegriff ein."
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Fehlgeschlagene Nachrichten"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Falsches Dateiformat"
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Keine Datei angegeben."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Bitte teilen Sie uns Ihre E-Mail Adresse mit und wir senden Ihnen einen Link zu, um Ihr Abonnement zu bearbeiten."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Füllen Sie untenstehendes Formular aus um sich zum Newsletter ${channel}' anzumelden. Beachten Sie dass dies nur für Neuanmeldungen gedacht ist, falls Sie bereits angemeldet sind ${link_start}klicken Sie hier um Ihre Abonnements ${link_end} zu bearbeiten."
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Wählen Sie einen Newsletter aus, für den Sie eine direkte Anmeldungen ermöglichen möchten."
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Erledigte Aufgaben"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Fusszeile des Portlets"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "E-Mail Adresse des Absenders"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Absender"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Erstellen"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML E-Mail"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Einleitender Text"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Sammler miteinbeziehen"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Eine E-Mail mit einem Bestätigungslink wurde an die eingegebene E-Mail Adresse gesendet."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Element wurde hinzugefügt."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Element wurde gelöscht."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Element wurde verschoben"
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Elemente"
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Aufgabe"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Letzte Änderung"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Verwalten Sie ihre Abonnements"
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Bearbeiten Sie ihre Abonnements"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Betreff"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "***Nachrichten für Zustellung markiert"
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Nachrichten erfolgreich versendet"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Wartende Nachrichten"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Nachrichten mit Fehlern"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Nachrichten mit Fehlern auf der Warteliste"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Block nach unten verschieben"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Block nach oben verschieben"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Ihre Abonnements"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Neue Nachrichten"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr ""
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Keine Elemente gefunden."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Keine Nachrichten auf der Warteliste"
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Nur einige Änderungen wurden gespeichert."
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Wartende Aufgaben"
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Bitte bestätigen Sie ihre Anmeldung"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Bitte geben Sie ein gültiges Datum an."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Bitte wählen Sie einen Newsletter dessen alte bzw. gesendete Nachrichten gelöscht werden sollen."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Bitte wählen Sie einen Newsletter dessen wartende Nachrichten gelöscht werden sollen."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Beschreibung des Portlets"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Kopfzeile des Portlets"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Vorschau senden"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Weiter"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Aufgaben ausführen"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "Liste vor dem Import leeren. "
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "Liste leeren."
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Block entfernen"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Einträge entfernen"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Alte Nachrichten entfernen"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "Anmeldungen entfernen."
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Antwort E-Mail Adresse"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Nachrichten wiederholen"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Freier Text"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Speichern"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Plane Zustellung"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Zeit planen"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Suche"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Abonnenten durchsuchen"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Sektionen"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Vorschau des Newsletters im Browser anzeigen."
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Wenn aktiviert werden die verfügbaren Variablen über die Kopfzeile bestimmt. Die Kopfzeile muss eine Spalte 'email' enthalten."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Senden"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Artikel '${item}' als Newsletter versenden"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "'${context}' über ${channel} versenden. "
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Als Newsletter versenden"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Vorschau versenden"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Wartende Nachrichten jetzt verschicken"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Gesendete Nachrichten"
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Wenn Sie bereits zu mindestens einem unserer Newsletter angemeldet sind, können Sie über ihre E-Mail Adresse einen Link für Ihre Abonnementverwaltung anfordern:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Fusszeile anzeigen?"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Vorschau anzeigen"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Singing & Dancing Konfiguration"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Standard Newsletter"
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Status"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Anmelden"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Direktes Anmelden ermöglichen?"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Zu ${channel} anmelden"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Abonnenten"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Anmeldungen exportiert."
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Abonnements"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Warteliste dieses Newsletters wurde erfolgreich geleert."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Alte Nachrichten dieses Newsletters wurde erfolgreich entfernt."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Zustellzeitpunkt erfolgreich geplant."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Text der in der Fusszeile dargestellt wird - falls leer wird der Titel des Newsletters verwendet."
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Dieser Text wird automatisch zum Beginn jeder Nachricht angezeigt. Sie können hier Variablen wie ${subject} verwenden."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Dieser Text wird automatisch am Ende jeder Nachricht angezeigt."
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "Es fehlt die E-Mail Adresse an welche die Vorschau versendet werden."
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "Das Trennzeichen der CSV-Datei. (Meist ',' oder ';', es sind keine Anführungszeichen erforderlich)."
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "Die Absendeadresse die in jeder Nachricht mit dieser Vorlage angezeigt wird."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Der Newsletter zu dem Anmeldungen möglich sind."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "Newsletter über den gesendet werden soll"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "Die Antwortadresse die in jeder Nachricht mit dieser Vorlage angezeigt wird."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Der Absendename der in jeder Nachricht dieses Newsletters angezeigt wird."
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "Diese CSS-Style Definitionen werden in jede Nachricht eingefügt."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "Verwendetes Template"
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Es scheint ein Fehler mit den eingegebenen Werten aufgetreten zu sein."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Mindestens ein Fehler ist aufgetreten."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Dies ist nur erforderlich, falls Sie auf 'Plane Zustellung' klicken."
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Dies ist nur erforderlich, falls Sie auf 'Vorschau versenden' klicken."
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Dieses Portlet erlaubt einem Besucher sich zu einem oder mehreren Newslettern anzumelden."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Titel"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Geben Sie den Titel des Portlets."
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Um die Anmeldung zum Newsletter '${channel}' zu bestätigen, klicken Sie bitte hier: ${url}."
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Anzahl der gesendeten Nachrichten"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Anzahl der erfolgreich gesendeten Nachrichten"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr ""
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Typ"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Abmelden"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Vom Newsletter abmelden"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Zurück zur Verwaltung der Sammler"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Zurück zur Singing & Dancing Konfiguration"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Zurück zur Website-Konfiguration"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Hochladen"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Laden Sie eine CSV-Datei hoch. Neue Abonnenten werden hinzugefügt, bereits bestehende überschrieben. Jede Zeile muss folgende getrennte Werte enthalten: ${columns}."
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Upload Liste neuer Abonnenten."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "Anmeldung mit einem Formular"
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "Statt für jeden Newsletter ein eigenes Formular mit Mailadresse usw. anzuzeigen wird nur ein einzelnes Formular angezeigt. Newsletter können per Checkboxen aktiviert werden. Dies ist nur möglich, wenn die Newsletter diesselben Eingaben verlangen."
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Ihre E-Mail Adresse ist bereits für diesen Newsletter angemeldet. Klicken Sie ${link_start}hier um Ihre Anmeldung zu bearbeiten${link_end}."
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Sie sind bereits angemeldet. Füllen Sie das untenstehende Formular aus und wir senden Ihnen einen Link zu, um Ihre Abonnements zu bearbeiten."
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Sie sind im Moment für folgende Newsletter angemeldet:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Sie haben diesen Newsletter nicht abonniert."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Sie können sich zu folgenden Newslettern anmelden:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Sie haben Ihre Anmeldung erfolgreich bestätigt."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Sie können hier Variablen verwenden wie ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Sie haben sich erfolgreich angemeldet."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Sie haben sich erfolgreich abgemeldet."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Sie erhalten diese E-Mail weil Sie sich für den Newsletter '${channel}' angemeldet haben."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Ihre E-Mail Adresse ist ungültig"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "Ihre E-Mail Adresse ist bereits angemeldet. Klicken Sie auf den 'Link zusenden' Knopf."
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Ihr Abonnement konnte nicht gefunden werden."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Ihre Abonnements wurden geändert."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr "Ein Newsletter besteht aus einer Ansammlung von intelligenten Ordnern und Textblöcken. Er stellt eine Reihe von Komponenten zur Anpassung und Darstellung von Informationen zur Verfügung. Weiters enthält er auch die Abonnements der Personen die sich angemeldet haben."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr "Sammler sind nützlich für automatisierte Newsletter. Sie sind verantwortlich für den Aufbau und die Inhaltsauswahl im Newsletter."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "Verändern Sie allgemein gültige Einstellungen wie sich Singing & Dancing verhält."
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Hier können Sie die Newsletterstatistik einsehen."
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Newsletter verwalten"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Sammler verwalten"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "Allgemeine Einstellungen"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Statistiken"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/el/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/el/LC_MESSAGES/collective.dancing.po
@@ -14,945 +14,1027 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.dancing\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "${channel} επιλογές"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} δεν υποστηρίζει προγραμματισμό ημερολογίου."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} εγγραφές ενημερώθηκαν επιτυχώς!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} εγγραφές ενημερώθηκαν επιτυχώς, ${numberremoved} απομακρύνθηκαν!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} εγγραφές ενημερώθηκαν επιτυχώς. ${numberremoved} απομακρύνθηκαν. ${numbernotadded} δεν μπορούσαν να προστεθούν. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} μηνύματα μπήκαν στην ουρά"
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} μηνύμα(τα) στάλθηκε/καν, ${failed} απέτυχε/αν."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 #, fuzzy
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Προσθέσθε Πλαίσιο Εγγραφής Καναλιού"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Διεύθυνση για την αποστολή της προεπισκόπησης"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Όλα τα απεσταλμένα και τα αποτυχημένα μηνύματα διαγράφηκαν"
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Ήδη εγγεγραμμένος/η;"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Προσαρτήστε το αυτόματα συλλεγόμενο περιεχόμενο σε αυτή την αποστολή"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Εφαρμογή"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Εφαρμογή αλλαγών"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Πίσω στα πλαίσια"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Παρακάτω βλέπετε ένα κατάλογο των ενημερωτικών δελτίων που διαθέτουμε. Αν έχετε ήδη εγγραφεί σε κάποια από αυτά μπορείτε να συμπληρώσετε τη φόρμα στο τέλος αυτής της σελίδας για να σας σταλεί ένας σύνδεσμος σε μια σελίδα από όπου μπορείτε να επεξεργαστείτε τις υπάρχουσες εγγραφές σας."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Χαιρετισμούς"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS Stylesheet"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Αλλάξτε τις εγγραφές σας στην ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Κλικάρετε εδώ για να διαχειριστείτε τις εγγραφές σας στην ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Κλικάρετε εδώ για να διαλέξετε τις επιλογές του συλλέκτη που ενεργοποιούνται αυτόματα, με την εγγραφή από αυτό το πλαίσιο."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Κλικάρετε εδώ για να εμφανίζεται το υποσέλιδο του πλαισίου"
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Κλικάρετε εδώ για να διαγραφείτε"
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Συνθέτης για το φορμάτ : ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Συνθέτες"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Επιβεβαιώστε την εγγραφή σας στο ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Επιβεβαιώνεται η εγγραφή σας"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Περιγραφή του πλαισίου"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Εμφανίζει μια φόρμα που σας επιτρέπει να στείλετε αυτό το περιεχόμενο σαν ενημερωτικό δελτίο"
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Μεταφόρτωση"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Διεύθυνση Ε-mail"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Επεξεργασία ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Επεξεργασία ${selector} για το ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 #, fuzzy
 msgid "Edit Mailing-list ${channel}"
 msgstr "Επεξεργασία καναλιού ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 #, fuzzy
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Επεξεργασία Πλαίσιου Εγγραφής Καναλιού"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Επεξεργασία υπαρχόντων εγγραφών"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Επεξεργασία ιδιοτήτων του συνθέτη"
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 #, fuzzy
 msgid "Edit the properties of the mailing-list."
 msgstr "Επεξεργασία ιδιοτήτων του καναλιού"
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Εισάγετε μια αναζήτηση για την εύρεση περιεχομένου"
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Αποτυχημένα μηνύματα"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Δεν δώθηκε αρχείο"
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 #, fuzzy
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Βρείτε το κανάλι για το οποίο θέλετε να ενεργοποιήσετε την άμεση εγγραφή"
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Κείμενο υποσέλιδου"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Από διεύθυνση"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Από όνομα"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Δημιουργία"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML E-Mail"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Κείμενο επικεφαλίδας"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Συμπερίληψη αντικειμένων συλλέκτη"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Σας στάλθηκαν πληροφορίες για το πως θα επιβεβαιώσετε τη συνδρομή σας"
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Το αντικείμενο προστέθηκε με επιτυχία"
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Το αντικείμενο διαγράφτηκε με επιτυχία"
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Το αντικείμενο μετακινήθηκε με επιτυχία"
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Αντικείμενα"
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Τελευταία αλλαγή"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Διαχειριστείτε ή προσθέστε εγγραφές"
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Διαχειριστείτε τις εγγραφές σας"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Θέμα μηνύματος"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Μηνύματα στάλθηκαν με επιτυχία"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Μηνύματα αναμένουν αποστολή"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Μηνύματα με σφάλματα"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Μηνύματα με σφάλματα σε αναμονή επαναδοκιμής"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Μετακινήστε το μπλοκ κάτω"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Μετακινήστε το μπλοκ πάνω"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Οι εγγραφές μου"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Νέα μηνύματα"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Ενημερωτικό δελτίο"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Δεν βρέθηκαν αντικείμενα."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Δεν υπάρχουν μηνύματα στην αναμονή"
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Μόνο ορισμένες από τις αλλαγές σας αποθηκεύτηκαν"
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Παρακαλούμε επιβεβαιώστε την εγγραφή σας"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Παρακαλούμε συμπληρώστε μια ημερομηνία."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Περιγραφή πλαισίου"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Επικεφαλίδα πλαισίου"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Προεπισκόπηση"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Προχωρήστε"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Απομακρύνετε το μπλοκ"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Απομακρύνετε τις εισαγωγές"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Διεύθυνση αποστολής απαντήσεων"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Μηνύματα επαναπροσπάθειας"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Πλούσιο κείμενο"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Προγραμματισμός διανομής"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Προγραμματισμένη ώρα"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Αναζήτηση εγγεγραμμένων"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Τμήματα"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Δείτε μια προεπισκόπηση του ενημερωτικού δελτίου μέσα στο φυλλομετρητή"
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Αποστολή"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Αποστολή του ${item} σαν ενημερωτικό δελτίο"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Αποστολή σαν ενημερωτικό δελτίο"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Προεπισκόπηση αποστολής"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Απεσταλμένα μηνύματα"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Εάν έχετε ήδη εγγραφεί σε κάποια από τις λίστες μας, παρακαλούμε χρησιμοποιήστε αυτή τη φόρμα για να ανακτήσετε ένα σύνδεσμο προς την προσωπική σελίδα εγγραφών σας"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Προβολή υποσέλιδου"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Προβολή προεπισκόπησης"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Ρυθμίσεις Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Κανονικό κανάλι"
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Εγγραφή"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Εγγραφή κατευθείαν από το πλαίσιο"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Εγγραφή στο ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Εγγεγραμμένοι"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Εγγεγραμμένοι εξήχθησαν"
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Εγγραφές"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Διανομή που προγραμματίστηκε με επιτυχία"
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 #, fuzzy
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Κείμενο στο υποσέλιδο - αν παραλειφθεί θα χρησιμοποιηθεί ο τίτλος του καναλιού"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Κείμενο που εμφανίζεται στην αρχή κάθε μηνύματος. Μπορείτε να χρησιμοποιήσετε έναν αριθμό μεταβλητών εδώ, συμπεριλαμβανομένου ${subject}"
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Κείμενο που εμφανίζεται στο τέλος κάθε μηνύματος"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "Η διεύθυνση αποστολέα που θα εμφανίζεται στα μηνύματα που στέλνονται από αυτό το συνθέτη"
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 #, fuzzy
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Το κανάλι για το οποίο ενεργοποιείτε τις εγγραφές"
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 #, fuzzy
 msgid "The mailing-list to send this through"
 msgstr "Το κανάλι από το οποίο θα σταλεί αυτό"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "Η διεύθυνση απαντήσεων που θα εμφανίζεται στα μηνύματα που στέλνονται από αυτό το συνθέτη"
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 #, fuzzy
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Το όνομα αποστολέα που θα εμφανίζεται στα μηνύματα που στέλνονται από αυτό το συνθέτη"
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "Το στυλ σελίδας που θα εφαρμόζεται στο έγγραφο"
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Μάλλον υπάρχει κάποιο λάθος σε πληροφορίες που εισάγατε"
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Υπήρξαν κάποια λάθη"
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Αυτό απαιτείται μόνο αν επιλέξετε 'Προγραμματισμένη διανομή' παρακάτω"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Αυτό απαιτείται μόνο αν επιλέξετε 'Αποστολή προεπισκόπησης' παρακάτω"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 #, fuzzy
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Αυτό το πλαίσιο επιτρέπει σε έναν επισκέπτη να εγγραφεί σε ένα συγκεκριμένο κανάλι ενημερωτικού δελτίου."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Τίτλος"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Τίτλος του εισαγώμενου πλαισίου"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Για να επιβεβαιώσετε την εγγραφή σας στο ${channel}, παρακαλούμε πατήστε εδώ: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Συνολικός αριθμός απεσταλμένων μηνυμάτων"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Συνολικός αριθμός απεσταλμένων μηνυμάτων με επιτυχία"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Ενεργοποίηση τώρα"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Τύπος"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Άγνωστο"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Διαγραφή"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Διαγραφή από το ενημερωτικό δελτίο"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Πάνω προς τη διαχείριση Συλλεκτών"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Πάνω προς τις ρυθμίσεις Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Πάνω προς την εγκατάσταση της ιστοσελίδας"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Μεταφόρτωση"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Μεταφορτώστε μια λίστα εγγεγραμμένων"
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Είστε ήδη εγγεγραμμένος/η. Συμπληρώστε τη φόρμα στο τέλος αυτής της σελίδας για να σταλεί ένας σύνδεσμος από όπου μπορείτε να επεξεργαστείτε την εγγραφή σας."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Είστε ήδη εγγεγραμμένος/η σε αυτά τα ενημερωτικά δελτία:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Δεν είστε εγγεγραμμένος/η σε αυτό το κανάλι."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Μπορείτε να εγγραφείτε σε αυτά τα ενημρωτικά δελτία:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Επιβεβαιώσατε την εγγραφή σας με επιτυχία."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Μπορείτε να χρησιμοποιήσετε έναν αριθμό μεταβλητών εδώ, όπως ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Εγγραφήκατε με επιτυχία."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Διαγραφήκατε με επιτυχία."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Λαμβάνετε αυτό το e-mail γιατί είστε εγγεγραμμένος/η στο ενημερωτικό δελτίο ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Η διεύθυνση e-mail σας δεν είναι έγκυρη"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Η εγγραφή σας δεν υπάρχει."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Η εγγραφή σας ενημερώθηκε."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 #, fuzzy
 msgid "description_channel_administration"
 msgstr "Ένα Κανάλι είναι κόμβος ρυθμίσεων. Δεν κάνει κάτι μόνο του. Παρέχει έναν αριθμό συνιστωσών που ρυθμίζονται. Είναι επίσης ο συλλέκτης των εγγραφών σε αυτό."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 #, fuzzy
 msgid "description_collector_administration"
 msgstr "Οι Συλλέκτες είναι χρήσιμοι για αυτόματα ενημερωτικά δελτία. Είναι υπεύθυνοι για τη συναρμολόγηση μια σειράς αντικειμένων προς δημοσίευση."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Δείτε τα στατιστικά του ενημερωτικού δελτίου"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 #, fuzzy
 msgid "label_channel_administration"
 msgstr "Διαχείριση Καναλιού"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Διαχείριση Συλλέκτη"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Στατιστικά"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/en/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/en/LC_MESSAGES/collective.dancing.po
@@ -14,911 +14,993 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr ""
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr ""
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr ""
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr ""
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr ""
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr ""
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr ""
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr ""
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr ""
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr ""
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr ""
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr ""
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr ""
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr ""
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr ""
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr ""
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr ""
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr ""
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr ""
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr ""
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr ""
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr ""
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr ""
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr ""
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr ""
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr ""
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr ""
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr ""
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr ""
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr ""
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr ""
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr ""
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr ""
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr ""
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr ""
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr ""
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr ""
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr ""
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr ""
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr ""
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr ""
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr ""
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr ""
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr ""
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr ""
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr ""
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr ""
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr ""
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr ""
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr ""
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr ""
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr ""
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr ""
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr ""
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr ""
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr ""
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr ""
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr ""
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr ""
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr ""
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr ""
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr ""
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr ""
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr ""
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr ""
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr ""
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr ""
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr ""
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr ""
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr ""
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr ""
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr ""
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr ""
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr ""
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr ""
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr ""
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr ""
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr ""
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr ""
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/es/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/es/LC_MESSAGES/collective.dancing.po
@@ -18,893 +18,975 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #. Default: "channel"
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "opciones de ${channel}"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
 #. Default: ""
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} mensajes puestos en cola"
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Añadir"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 #, fuzzy
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Añadir portlet de suscripción de canales"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Dirección a la cual enviar la vista previa"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Se han borrado todos los mensajes enviados y fallidos"
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "¿Ya estás suscrito?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Aplicar cambios"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Volver a portlets"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Más abajo hay una lista de los boletines de novedades que ofrecemos. Si ya estás suscrito a algunos de ellos, puedes rellenar el formulario que aparece al final de esta página para que se te envíe un correo electrónico con un enlace desde el cual puedes modificar tu suscripciones."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Saludos cordiales"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 #, fuzzy
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Cambia tus suscripciones a ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Haz clic aquí para gestionar tus suscripciones en ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Haz clic aquí para que las opciones de la colección se seleccionen automáticamente cuando se haga una suscripción desde este portlet."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Haz clic aquí para mostrar el pie del portlet"
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Haz clic aquí para anular la suscripción."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
 #. Default: "channel-title"
-#: ./composer.py:357
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Confirma tu suscripción a ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Confirmando tu suscripción"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Descripción del portlet tal y como se muestra"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr ""
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Dirección de correo electrónico"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr ""
 
 #. Default: ""
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Editar ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
 #. Default: "channel"
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 #, fuzzy
 msgid "Edit Mailing-list ${channel}"
 msgstr "Editar canal ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 #, fuzzy
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Editar el portlet de suscripción a canal"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Editar las suscripciones existentes"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Mensajes fallidos"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 #, fuzzy
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Encontrar el canal al que permitir suscripciones directas."
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Texto del pie"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "Correo electrónico HTML"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Incluir los elementos de la colección"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Se te ha enviado información sobre cómo confirmar tu suscripción."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Se ha añadido el elemento"
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Se ha borrado el elemento"
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "El elemento se ha movido"
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr ""
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Último cambio"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Gestionar tus suscripciones"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Mensajes enviados con éxito"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Mensajes en espera para enviar"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Mensajes con errores"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Mensajes con errores en la cola de reintento"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Mover el bloque para abajo"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Mover el bloque para arriba"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Mis suscripciones"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Mensajes nuevos"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Newsletter"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "No se ha puesto ningún mensaje en la cola."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Por favor, confirma tu suscripción"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr ""
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Descripción del portlet"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Cabecera del portlet"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Proceder"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Eliminar el bloque"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr ""
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Reintentar el envío"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Texto enriquecido"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr ""
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Secciones"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Enviar"
 
 #. Default: ""
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Enviar ${item} como boletín de noticias"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Enviar vista previa"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Mensajes enviados"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Ya debes estar suscrito a alguna de nuestras listas. Por favor, usa este formulario para que se te envíe un enlace a la página de tus suscripciones personales:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Mostrar pie"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Mostrar vista previa"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Configuración de Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Suscribirse"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Suscribir directamente desde el portlet"
 
 #. Default: "channel"
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Suscribirse a ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 #, fuzzy
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Texto del pie - si se omite se usará el título del canal"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 #, fuzzy
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Canal al cual permitir las suscripciones."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 #, fuzzy
 msgid "The mailing-list to send this through"
 msgstr "Canal a través del cual mandar esto"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Parece que hay un error en la información que has introducido."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Ha habido algunos errores."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Esto sólo se requiere si haces clic en \"Enviar vista previa\" más abajo"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 #, fuzzy
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Este portlet permite a un visitante suscribirse a un canal específico de boletín de noticias."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Título"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Título del portlet tal y como aparece en el sitio"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Para confirmar tu suscripción a ${channel}, por favor haz clic aquí: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Total de mensajes enviados"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Número total de mensajes que se han podido enviar"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Disparar ahora"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Tipo"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Darse de baja"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Darse de baja de la suscripción al boletín."
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Subir a Administración de colecciones"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Subir a Configuración de Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Subir a Configuración del sitio"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Ya estás suscrito. Rellena el formulario que aparece al final de esta página para que se te envíe un enlace desde el cual puedes modificar las condiciones de tu suscripción."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Actualmente estás suscrito a los siguientes boletines:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "No estás suscrito a este canal."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Puedes suscribirte a los siguientes boletines:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Has confirmado tu suscripción correctamente."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Te has suscrito correctamente."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Te has dado de baja de la suscripción."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Estás recibiendo este correo electrónico porque estás suscrito al boletín de noticias ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "La dirección de correo electrónico es incorrecta"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "No conocemos tu suscripción."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Tus suscripciones se han actualizado."
 
@@ -912,7 +994,7 @@ msgstr "Tus suscripciones se han actualizado."
 # "        itself.  Rather, it provides a number of components to configure\n"
 # "        and work with.  It is also the container of subscriptions to it."
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 #, fuzzy
 msgid "description_channel_administration"
 msgstr "Un canal es un elemento esencial para la configuración. No hace nada por sí mismo. Proporciona una serie de componentes con los que trabajar que se pueden configurar. También es el contenedor que registra sus propias suscripciones."
@@ -920,7 +1002,7 @@ msgstr "Un canal es un elemento esencial para la configuración. No hace nada po
 # "Collectors are useful for automatic newsletters.  They are\n"
 # "      responsible for assembling a list of items for publishing."
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 #, fuzzy
 msgid "description_collector_administration"
 msgstr ""
@@ -928,47 +1010,47 @@ msgstr ""
 "Sirven para recopilar la lista de elementos que hay que publicar."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Ver las estadísticas de boletines"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 #, fuzzy
 msgid "label_channel_administration"
 msgstr "Administración de canales"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Administración de colecciones"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Estadísticas"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/eu/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/eu/LC_MESSAGES/collective.dancing.po
@@ -17,948 +17,1030 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.dancing\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "${channel} aukerak"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name}k ez du antolaketa onartzen."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} harpidetza ondo eguneratu dira!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} harpidetza ondo eguneratu dira, ${numberremoved} ezabatu dira!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} harpidetza ondo eguneratu dira, ${numberremoved} ezabatu dira. ${numbernotadded} ezin izan dira gehitu. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} mezu ilaran."
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} mezu ilaran gorde dira."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} mezu bidali dira, ${failed} errore."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Gehitu"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 #, fuzzy
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Gehitu buletinera harpidetzeko portleta"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Aurreikuspen mezua bidaltzeko helbidea"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Egindako lan guztiak garbituta"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Egin gabe zeuden lanak eginda"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Bidalitako eta huts egindako mezu guztiak ezabatuta"
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Jada harpidetuta zaude?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Bildutako edukia automatikoki gehitu bidalketara"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Gorde"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Aldaketak egin"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Portletetara itzuli"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Dauzkagun buletinen zerrenda daukazu behean. Hauetakoren batera harpidetuta bazaude, bukaeran dagoen formularioa betez zure harpidetzak editatzeko helbidea bidaliko dizugu."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Agur bat"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS estilo orria"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV fitxategiak goiburukoa dauka"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "CSV fitxategiko edukien banatzailea"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "${site_title} webguneko zure harpidetzak aldatu"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Egindako lanak garbitu"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Ilaran dauden mezuak garbitu"
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Egin klik hemen ${site_title} webguneko zure harpidetzak kudeatzeko:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Porltlet honetatik harpidetzean automatikoki aktibatuko diren informazio-bildumen aukerak aukeratzeko egin klik hemen."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Portletaren oina erakusteko hemen egin klik"
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Egin klik hemen harpidetza eteteko"
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Formatuarentzako egilea: ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Egileaak"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "${channel-title} buletinerako zure harpidetza konfirmatu"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Zure harpidetza konfirmatzen"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Pertsonalizatutako gaia"
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Bidalketa data"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Portletaren deskribapena"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Eduki hau buletin gisa bidaltzeko formularioa erakustarazten du."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Deskargatu"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "E-posta helbidea"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Editatu"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "${collector} editatu"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "${channel} buletinean ${selector} editatu"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 #, fuzzy
 msgid "Edit Mailing-list ${channel}"
 msgstr "${channel} buletina editatu"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 #, fuzzy
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Buletinera harpidetzeko portleta editatu"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Harpidetzak editatu"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Egilearen propietateak editatu"
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 #, fuzzy
 msgid "Edit the properties of the mailing-list."
 msgstr "Buletinaren propietateak editatu"
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 #, fuzzy
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Idatzi bidaliko den buletinaren Gaia eremua. Utzi hutsik defektuzko gaia erabiltzeko."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Edukia bilatzeko testua sartu"
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Errorea harpidedunen fitxategia inportatzerakoan. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Huts egin duten mezuak"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Fitxategiaren formatua ez da egokia."
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Ez duzu fitxategirik kargatu."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Bete ezazu beheko formularioa zure harpidetzak editatzeko helbidea e-postaz jasotzeko."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 #, fuzzy
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Harpidetzak egiteko buletina aukeratu"
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Amaitutako lanak"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Oineko testua"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Bidaltzailearen helbidea"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Bidaltzailearen izena"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Sortu"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML e-posta"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Goiburuko testua"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Informazio-bildumako elementuak gehitu."
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Zure harpidetza konfirmatzeko informazioa bidali dizugu."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Elementua ondo gehitu da."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Elementua ezabatuta."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Elementua ondo mugitu da-"
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Elementuak"
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Lanaren izenburua"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Azken aldaketa"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Harpidetzak kudeatu edo gehitu"
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Zure harpidetzak kudeatu"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Mezuaren gaia"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Bidaltzeko ilaran dauden mezuak"
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Ondo bidalitako mezuak"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Bidaltzeko zain dauden mezuak"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Erroredun mezuak"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Berriz saiatzeko ilaran erroredun mezuak daude"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Blokea behera mugitu"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Blokea gora mugitu"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Nire harpidetzak"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Mezu berriak"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Buletina"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Ez da elementurik aurkitu."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Ez dago mezurik ilaran"
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Zure aldaketa batzuk bakarrik gorde dira"
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Egiteke dauden lanak"
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Konfirmatu zure harpidetza."
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Data bat idatzi."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Ezabatu beharreko mezuak aukeratu."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Garbitu beharrezko mezu berriak dituzten elementuak aukeratu."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Portletaren deskribapena"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Portletaren goiburua"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Aurreikusi"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Aurrera"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Lanak abiarazi"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Blokea ezabatu"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Sarrerak ezabatu"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Mezu zaharrak ezabatu"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Erantzuteko helbidea."
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Berriz saiatu"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Testua"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Gorde"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Banaketa antolatu"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Programatutako ordua"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Bilatu"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Harpidedunak bilatu"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Atalak"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Buletinaren aurrebista nabigatzailean ikusi."
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Aukeratu CSV fitxategiaren goiburu-lerroa erabilil nahi baduzu. Lerro horrek gutxienez 'email' izeneko zutabe bat izan behar du."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Bidali"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "${item} buletin gisa bidali"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Buletin gisa bidali"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Aurrebista-mezua bidali"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Ilaran dauden mezuak orain bidali"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Mezuak bidalita"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Gure zerrendetakoren batera harpidetuta bazaude, erabili formulario hau zure harpidetzak kudeatzeko helbidea lortzeko:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Oina erakutsi"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Aurrebista ikusi"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Singin & Dancingen konfigurazioa"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Buletin estandarra"
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Egoera"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Harpidetu"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Portletetik zuzenean harpidetu"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "${channel} buletinera harpidetu"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Harpidedunak"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Harpidedunak esportatuta."
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Harpidetzak"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 #, fuzzy
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Mezuen ilarak ondo hustu dira."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 #, fuzzy
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Mezu zaharrak ondo ezabatu dira."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Ondo antolatutako banaketa."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 #, fuzzy
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Oineko testua - hutsik utziz gero, buletinaren izena erabiliko da."
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Mezu guztien hasieran agertuko den testua. Hemen, hainbat aldagai erabil ditzakezu, adibidez ${subject}"
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Mezu guztien oinean agertuko den testua"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "CSV fitxategiko edukien banatzailea. (Normalean ',' edo ';' izan ohi da, baina komatxoak ez dira beharrezkoak)"
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "Bidalitako mezuetan bidaltzaile gisa agertuko den helbidea."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 #, fuzzy
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Zein buletinetara harpidetu"
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 #, fuzzy
 msgid "The mailing-list to send this through"
 msgstr "Hau bidaltzeko buletina"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "Bidalitako mezuetan agertuko den nori-erantzuteko helbidea."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 #, fuzzy
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Bidalitako mezuetan agertuko den bidaltzailearen izena."
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "Dokumentuari aplikatuko zaion estilo-orria."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Emandako informazioak erroreren bat duela dirudi."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Errore batzuk egon dira."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "'Banaketa antolatun'-n klik egiten baduzu bakarrik da beharrezkoa."
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "'Aurreikuspen mezua bidali'-n klik egiten baduzu bakarrik da beharrezkoa."
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 #, fuzzy
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Buletin jakin batera harpidetzeko portleta"
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Izenburua"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Portletaren izenburua"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Egin klik hemen ${channel} buletinera zure harpidetza konfirmatzeko: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Guztira bidalitako mezu kopurua:"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Ondo bidalitako mezuak"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Orain bidali"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Mota"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Ezezaguna"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Harpidetza eten"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Buletinetik harpidetza eten"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Informazio-bildumen kudeaketara joan"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Singing & Dancingen konfiguraziora joan"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Atariaren konfiguraziora joan"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Kargatu"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Harpidedunen zerrenda duen CSV fitxategia kargatu. Datu-basean aurretik dauden harpidedunen datuak gainidatzi egingo dira. Lerro bakoitzak informazio hau eduki behar du: ${columns}"
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Harpidedunen zerrenda kargatu."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Harpidetuta zaude. Orrialdearen bukaeran dagoen formularioa bete ezazu zure harpidetza konfiguratzeko helbidea lortzeko."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Buletin hauetara harpidetuta zaude:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Ez zaude buletin honetara harpidetuta."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Buletin hauetara harpidetu zaitezke:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Zure harpidetza baieztatu duzu."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Hemen aldagaiak erabil ditzakezu, adibidez ${site_title}"
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Ondo harpidetu zara."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Ondo ezabatu da zure harpidetza."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Mezu hau ${channel} buletinera harpidetuta zaudelako jaso duzu."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Zure e-posta helbidea ez da baliozkoa"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Ez zaude harpidetuta."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Zure harpidetza eguneratu da."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 #, fuzzy
 msgid "description_channel_administration"
 msgstr "Konfigurazioa besterik ez dago hemen. Bere kabuz ez du ezer egiten, baina konfiguratzeko hainbat elementu ditu. Harpidetzak ere bertan gordetzen dira."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 #, fuzzy
 msgid "description_collector_administration"
 msgstr "Informazio-bildumak buletin automatikoentzat dira erabilgarriak. Bidali beharreko elementu-zerrenda automatikoki sortzeaz arduratzen dira."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Buletinaren estatistikak ikusi"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 #, fuzzy
 msgid "label_channel_administration"
 msgstr "Buletinen kudeaketa"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Informazio-bildumen kudeaketa"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Estatistikak"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/fr/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/fr/LC_MESSAGES/collective.dancing.po
@@ -16,911 +16,993 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "Language: \n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "Options de ${channel}"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} ne supporte pas la planification."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} abonnements mis à jour avec succès !"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} abonnements mis à jour avec succès, ${numberremoved} retirés!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} abonnements mis à jour avec succès. ${numberremoved} retirés. ${numbernotadded} n'ont pu être ajoutés. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberremoved} abonnements supprimés avec succès!"
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} messages mis en file d'attente."
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} message(s) en file d'attente."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} message(s) envoyé(s), ${failed} dont l'envoi a échoué."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Ajouter"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Ajouter un portlet d'abonnement"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr "Ajouter un élément à ${title}"
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr "Ajouter ou modifier une newsletter qui utilisera des collecteurs et envoyer un email avec un ensemble spécifiques d'information de votre site, aux abonnés, à un moment définit"
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Adresse à laquelle envoyer la pré-visualisation"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Les taches achevées ont été effacées"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr "Les tâches en attente ont été effacées"
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Les taches en attente ont été éxécutées"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Tous les messages envoyés ou dont l'envoi a échoué ont été supprimés"
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Déjà abonné ?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Ajouter automatiquement le contenu collecté à cette liste de diffusion"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Appliquer les changements"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Retourner aux portlets"
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Vous voyez ci-dessous la liste des newsletters que nous proposons. Si vous êtes déjà abonnés à certaines d'entre elles vous pouvez compléter le formulaire situé en fin de page afin de recevoir un lien vers la page d'édition de vos abonnements existant."
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Cordialement"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "Feuille de styles CSS"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "Le fichier CSV contient une ligne d'en-tête"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "Séparateur CSV"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr "Impossible d'identifier votre inscription. Veuillez vérifier l'url."
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Modifier votre abonnement à ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Effacer les taches terminées"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr "Effacer les tâches en attente"
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Effacer les messages en attente"
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Cliquez ici pour accéder à la gestion de votre abonnement à ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Cliquez ici pour sélectionner les options de la collection à activer automatiquement en cas d'inscription à ce portlet."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Cliquez ici pour afficher le portlet de pied de page."
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Cliquez ici pour annuler votre abonnement"
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr "Collection pour ${title}"
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr "Collection: ${title}"
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr "Bloc de collecte"
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr "Bloc de collecte: ${title}"
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Mise en page pour le format : ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Mises en page"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Confirmez votre abonnement à ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Confirmez votre abonnement"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr "Sélection du contenu"
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Sujet personnalisé"
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Date d'execution"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Description du portlet affiché"
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Affiche un formulaire permettant d'envoyer ce contenu en tant que newsletter."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Télécharger"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Adresse e-mail"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Éditer"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Éditer ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Éditer ${selector} pour ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr "Modifier ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Modifier le portlet d'inscription"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Modifier les abonnements existant"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr "Editer le dossier intelligent"
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Modifier les propriétés de cette mise en page"
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "Modifier les propriétés de cette liste"
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Entrez un sujet personnalité pour votre newsletter ici. Laissez blanc pour utiliser le sujet par défaut de ce contenu pour cette liste de diffusion."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Rechercher un contenu."
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Erreur durant l'import de ce fichier d'abonnement. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Messages dont l'envoi à échoué"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Ce fichier a un format incorrect"
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Le fichier n'a pas été fourni."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Remplissez le formulaire ci dessous pour recevoir un mail. Ce mail comportera un lien vous permettant d'éditer vos préférences."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Remplissez le formulaire ci dessous pour souscrire à ${channel}. Il est à noter que ceci est pour les nouvelles inscriptions. Cliquer ${link_start} ici pour modifier vos inscriptions${link_end}."
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Sélectionner la liste de diffusion à laquelle vous souhaitez permettre l'inscription"
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Tâches terminées"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Pied de page"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Adresse de l'émetteur "
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Nom de l'émetteur"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Générer"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "E-mail au format HTML"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "En-tête"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Inclure les éléments de la collection"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Les informations expliquant comment confirmer votre abonnement vous ont été envoyées."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Élément ajouté avec succès."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Élément supprimé avec succès."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Élément déplacé avec succès."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Éléments"
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Titre de la tâche"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Dernière modification"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr "Dernières actualités"
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Gérer ou ajouter des abonnements."
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Gérer vos abonnements"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Sujet du message"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Message en attente de diffusion."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Messages envoyés avec succès"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Messages en attente d'envoi"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Messages contenant des erreurs"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Messages contenant des erreurs en attente d'un nouvel essai"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Déplacer le bloc vers le bas"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Déplacer le bloc vers le haut"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr "Doit être une référence faible (reçu ${title})"
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Mes abonnements"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Nouveaux messages"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Newsletter"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr "Les newsletters"
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Aucun élément trouvé."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Aucune message en attente."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr "N'enlever que les abonnés présents dans la liste téléchargée."
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Seules quelques-unes de vos modifications on été sauvegardées."
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Tâches en attente"
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Veuillez confirmer votre abonnement"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Veuillez entrer une date."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Veuillez sélectionner des éléments à retirer."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Veuillez sélectionner des éléments contenant des nouveaux messages à effacer."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr "Veuillez sélectionner la file d'attente de couriel que vous voulez envoyer."
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Description du portlet"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Portlet d'en-tête"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Pré-visualisation"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Éxécuter"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Éxécuter les taches"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "Purger la liste avant l'import."
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "Purger la liste."
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Retirer le bloc"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Retirer les entrées"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Retirer les anciens messages"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "Enlever les abonnés à la liste"
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Répondre à l'adresse"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Faire un nouvel essai pour ces messages"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Texte enrichi"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr "Texte riche: ${title}"
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Planifier la livraison"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Heure de planification"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Rechercher"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Rechercher des abonnés"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Sections"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Afficher une pré-visualisation de la newsletter directement dans le navigateur"
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Cochez cette case si vous souhaitez utiliser la première ligne du fichier csv pour désigner les noms des variables. Cette ligne doit contenir la valeur 'email'."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Envoyer"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Envoyer ${item} en tant que newsletter"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "Envoyer '${context}' sur ${channels}."
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Envoyer une newsletter"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Envoyer la pré-visualisation"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Envoyer les messages en attente immédiatement"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Envoyer les messages"
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Dans le cas ou vous seriez déjà abonné à une de nos listes, veuillez utiliser ce formulaire pour récupérer un lien vers la page présentant vos abonnements."
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Afficher le pied de page"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Afficher la pré-visualisation"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Configuration de Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Liste de diffusion standard"
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Statut"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "S'abonner"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "S'abonner directement depuis le portlet"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "S'abonner à ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Abonnés"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Les abonnés ont été exportés."
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Abonnements"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Les messages en attente des listes de diffusion ont été effacés avec succès."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Les anciens messages des listes de diffusion ont été retirés avec succès."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "La livraison a été planifiée avec succès."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr "Template"
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Texte du pied de page - Le titre de la liste de diffusion est utilisé en cas d'omission"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Texte devant apparaitre au début de tout message. Vous pouvez utiliser quelques variables ici, telles que ${subject}."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Texte à faire apparaitre à la fin de tout message"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "L'adresse du destinataire de la pré-visualisation est manquante."
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "Le séparateur de champs utilisé dans votre fichier CSV. (Habituellement ',' ou ';', sans les guillemets)."
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "L'adresse de l'émetteur qui apparaitra dans les messages envoyés avec cette mise en page"
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "La liste de diffusion auquelle il faut lié l'abonnement."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "La liste de diffusion sur laquelle on procède à l'envoi"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "L'adresse de réponse qui apparaitra dans les messages envoyés avec cette mise en page"
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Le nom de l'émetteur qui apparaitra dans les messages envoyés à partir de cette liste de diffusion"
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "La feuille de styles sera appliquée au document."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "Le template qui sera utilisé."
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Il semble y avoir une erreur avec les informations que vous avez fournies."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Des erreurs sont survenues."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Ceci est obligatoire uniquement si vous cliquez sur 'Diffusion planifiée' ci-dessous"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Ceci est obligatoire uniquement si vous cliquez sur \"Envoyer la pré-visualisation\" ci-dessous"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Ce portlet permet aux visiteurs de s'abonner à une newsletter."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Titre"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Titre du portlet affiché"
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Pour confirmer votre abonnement à ${channel}, veuillez cliquez ici : ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Total des messages envoyés"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Total des messages envoyés avec succès"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Déclencher immédiatement"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Type"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Se désabonner"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Se désabonner de la newsletter"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Remonter vers l'administration de la collection"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr "Remonter vers l'administration des listes de diffusion"
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Remonter vers l'administration de Singing·&·Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Remonter vers la configuration du site"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Upload"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Veuillez procéder à l'upload d'une liste d'abonnés ici. Les abonnés déjà présents dans la base de donnés seront écrasés. Chaque ligne devrait contenir : ${columns}."
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Upload de la liste d'abonnés"
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "Utiliser une seul formulaire d'inscription"
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "Utiliser un seul formulaire d'inscription lorsque cela est possible"
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Vous êtes déjà inscrit à cette newsletter. Cliquer ici pour ${link_start}modifier vos inscriptions${link_end}."
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Vous êtes déjà abonnés. Complétez le formulaire au pied de cette page afin de recevoir un lien vers la page d'édition de vos abonnements."
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Vous êtes déjà abonnés à ces newsletters : "
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Vous n'êtes pas abonnés à cette liste de diffusion"
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr "Vous ne pouvez pas ajouter d'abonnements en supression exclusive!"
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Vous pouvez vous abonner aux newsletters suivantes :"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Vous avez confirmé votre abonnement avec succès."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Vous pouvez utilisez quelques variables ici, telles que ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Votre abonnement est un succès."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Vous avez été désabonnés avec succès."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr "Vous avez été désabonnés avec succès"
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Vous recevez cet email car vous êtes abonnés à la newsletter ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Votre adresse e-mail est invalide"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "Votre adresse email est déjà inscrite. Cliquer sur le bouton ci dessous pour récupérer vos inscriptions."
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Nous n'avons pas de trace de votre inscription."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Votre inscription a été mise à jour."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr "Une liste de diffusion est un ensemble de configuration. Elle ne fait rien en tant que telle. Elle met à disposition un ensemble de composants à configurer et à utiliser. C'est aussi le conteneur des abonnements à la liste."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr "Les collections sont utiles pour les newsletters automatiques. Elles sont responsables d'assembler un ensemble d'éléments à publier."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "Modifier certains aspects"
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "L'activité de vos newsletters en détails."
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Administration des listes de diffusion"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Administration des collections"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "Paramètres globaux"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr "(Requis)"
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Statistiques"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr "Champs requis"
 

--- a/collective/dancing/locales/he/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/he/LC_MESSAGES/collective.dancing.po
@@ -17,932 +17,1014 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.dancing\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr ""
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr ""
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr ""
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr ""
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr ""
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr ""
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr ""
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr ""
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr ""
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "לחץ כאן להסרה מרשימת התפוצה"
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "אישור הרשמה לניוזלטר"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "אישור הרשמתך לניוזלטר"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr ""
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr ""
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr " דוא''ל"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr ""
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr ""
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr ""
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr ""
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr ""
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr ""
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr ""
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr ""
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "לינק לאישור נשלח אליך"
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr ""
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr ""
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr ""
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr ""
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr ""
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr ""
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr ""
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr ""
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr ""
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr ""
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr ""
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr ""
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr ""
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr ""
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr ""
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "אנא אשר את הרשמתך לניוזלטר"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr ""
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr ""
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr ""
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr ""
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr ""
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr ""
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr ""
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr ""
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr ""
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr ""
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr ""
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr ""
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr ""
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "."
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr ""
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr ""
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr ""
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "כתובת המייל אינה תקינה"
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "יש להקליד מייל"
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr ""
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr ""
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "לאישור הרשמתך לניוזלטר, לחץ על הקישור הבא: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr ""
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr ""
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr ""
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr ""
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "הסרה מרשימת תפוצה"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr ""
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr ""
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr ""
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr ""
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr ""
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "זה עתה הוסרת מרשימת התפוצה של האתר"
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "הרשמתך בוצעה בהצלחה"
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "הוסרת מרשימת התפוצה בהצלחה"
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "שלום רב: הינך מקבל מייל זה לאחר הרשמתך לקבלת ניוזלטר מאתר CancerHelp"
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr ""
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr ""
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr ""
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr ""
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr ""
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr ""
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr ""
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr ""
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr ""
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/hu/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/hu/LC_MESSAGES/collective.dancing.po
@@ -17,931 +17,1013 @@ msgstr ""
 "X-Poedit-Language: Hungarian\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr ""
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr ""
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr ""
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr ""
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr ""
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr ""
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr ""
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr ""
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr ""
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr ""
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr ""
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr ""
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr ""
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr ""
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr ""
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr ""
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr ""
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr ""
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr ""
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr ""
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr ""
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr ""
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr ""
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr ""
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr ""
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr ""
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr ""
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr ""
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr ""
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr ""
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr ""
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr ""
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr ""
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr ""
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr ""
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr ""
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr ""
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr ""
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr ""
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr ""
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr ""
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Végrehajt"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr ""
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr ""
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr ""
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr ""
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr ""
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr ""
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Elküld"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr ""
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr ""
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr ""
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr ""
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr ""
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr ""
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr ""
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr ""
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr ""
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Cím"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr ""
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr ""
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr ""
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr ""
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr ""
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr ""
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr ""
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr ""
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr ""
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr ""
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr ""
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr ""
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr ""
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr ""
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr ""
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr ""
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Az Ön feliratkozása nem ismeretes előttünk."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr ""
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr ""
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr ""
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr ""
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr ""
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr ""
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr ""
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/it/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/it/LC_MESSAGES/collective.dancing.po
@@ -1,7 +1,7 @@
 # translation of collective.dancing.
 # <kevin.samuel@pilotsystems.net>, 2008.
-# 
-# 
+#
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.dancing 0.9.0\n"
@@ -21,911 +21,993 @@ msgstr ""
 "X-Poedit-Language: Italian\n"
 "X-Poedit-Country: ITALY\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "Opzioni di ${channel}"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} non supporta la pianificazione."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} iscrizioni aggiornate con successo!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} iscrizioni aggiornate con successo, ${numberremoved} rimosse!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} iscrizioni aggiornate con successo. ${numberremoved} rimosse. ${numbernotadded} non possono essere aggiunte. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberremoved} iscrizioni rimosse con successo!"
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} messaggi accodati."
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} messaggio(i) accodato(i)."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr "${queued} messaggio(i) accodati per la spedizione."
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} messagio(i) inviato(i), ${failed} fallito(i)."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr "0 messaggi accodati per la spedizione. La newsletter '${newsletter_path}' non è stata trovata."
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Aggiungi il Riquadro Iscrizione alla Mailing-list"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr "Aggiungi elemento a ${title}"
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr "Aggiungi o modifica mailing-list che faranno uso di collettori per raccogliere e spedire via e-mail insiemi specifici di informazioni dal tuo sito, agli indirizzi e-mail iscritti, a intervalli pianificati."
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Indirizzo a cui inviare l'anteprima"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Rimossi tutti i lavori completati"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr "Tutti i lavori in attesa sono stati cancellati"
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Elaborati tutti i lavori in attesa"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Eliminati tutti i messaggi inviati e falliti"
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Già iscritto?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Aggiunge in questo invio i contenuti raccolti automaticamente"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Applica"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Applica modifiche"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Indietro ai riquadri"
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Di seguito un elenco delle newsletter che offriamo. Se sei già iscritto ad alcune di queste, puoi compilare il questionario alla fine di questa pagina per ricevere un collegamento verso dove puoi modificare le tue iscrizioni esistenti."
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Cordiali saluti"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "Foglio di stile CSS"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV contiene una riga d'intestazione"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "Separatore CSV"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr "Non è stato possibile trovare la tua iscrizione. Per favore controlla l'URL."
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Modifica la tua iscrizione a ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Rimuovi lavori completati"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr "Rimuovi i lavori pendenti"
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Rimuovi messaggi accodati"
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Clicca qui per gestire la tua iscrizione a ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Clicca qui per scegliere di abilitare automaticamente le opzioni del collettore, quando ci si iscrive tramite questo riquadro."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Clicca qui per mostrare il piè di pagina del riquadro."
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Clicca qui per cancellare l'iscrizione."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr "Collezione per ${title}"
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr "Collezione: ${title}"
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr "Blocco collezione"
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr "Blocco collezione: ${title}"
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Impaginazione per il formato : ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Impaginazione"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Conferma la tua iscrizione a ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Conferma dell'iscrizione"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr "Selezione contenuto"
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Oggetto Personalizzato"
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Data d'esecuzione"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Descrizione del riquadro renderizzato"
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Mostra modulo che permette di inviare questo contenuto come una newsletter."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Download"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Indirizzo e-mail"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Modifica"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Modifica ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Modifica ${selector} per ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr "Modifica Mailing-list ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Modifica Riquadro di Iscrizione alla Mailing-list"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Modifica iscrizioni esistenti"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr "Modifica lo smart folder"
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Modifica le proprietà del compositore."
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "Modifica le proprietà della mailing-list."
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Inserire qui una linea oggetto personalizzata per la newsletter. Lascia vuoto per usare l'oggetto predefinito per il contenuto scelto e la mailing-list."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Inserire una chiave di ricerca per trovare il contenuto."
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Errore durante l'importazione del file degli iscritti. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Messaggi falliti"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Il file ha un formato non corretto."
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Il file non è stato inserito."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Compilare il modulo seguente per ricevere una e-mail con un collegamento dal quale poter modificare l'iscrizione."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Compilare il form seguente per iscriversi a ${channel}. Notare che riguarda nuove iscrizioni. Cliccare qui ${link_start} per inserire le proprie iscrizioni${link_end}."
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Scegliere la mailing-list a cui si desidera abilitare l'iscrizione diretta"
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Lavori terminati"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Piè di pagina"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Indirizzo mittente"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Nome mittente"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Genera"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "E-mail in formato HTML"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "In testa"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Includi elementi del collettore"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Ti sono state inviate le informazioni su come confermare l'iscrizione."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Elemento aggiunto con successo."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Elemento eliminato con successo."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Elemento spostato con successo."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Elementi"
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Titolo lavoro"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Ultima modifica"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr "Ultime news"
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Gestisci o aggiungi iscrizioni."
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Gestisci le tue iscrizioni"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Oggetto del messaggio"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Messaggi accodati per la consegna."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Messaggi inviati con successo"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Messaggi in attesa di invio"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Messaggi con errori"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Messaggi con errori in coda per essere riprocessati"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Muovi blocco verso il basso"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Muovi blocco verso l'alto"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr "Dovrebbe essere un riferimento debole (ho ${title})"
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Le mie iscrizioni"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Nuovi messaggi"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Newsletter"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr "Newsletter"
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Nessun elemento trovato."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Nessun messaggio in coda."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr "Elimina solo iscritti presenti in questa lista."
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Solo alcuni dei cambiamenti apportati sono stati salvati"
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Lavori in attesa"
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Per favore conferma la tua iscrizione"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Inserire una data."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Selezionare elementi da rimuovere."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Selezionare elementi con nuovi messaggi da cancellare."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr "Selezionare quali e-mail accodate della mailing-list si desidera inviare."
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Descrizione riquadro"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Titolo del riquadro"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Anteprima"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Continuare"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Esegui lavori"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "Svuota completamente la lista prima di importare."
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "Svuota lista."
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Rimuovere blocco"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Rimuovere inserimenti"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Rimuovere vecchi messaggi"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "Rimuovi iscritti alla lista."
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Indirizzo di risposta"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Messaggi ritentare"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Rich text"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr "Testo: ${title}"
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Salva"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Schedulare invio"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Orari pianificati"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Ricerca"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Ricerca iscritti"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Sezioni"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Visualizzare un'anteprima della newsletter direttamente nel browser."
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Seleziona questo se desideri utilizzare la riga d'intestazione csv per designare le variabili del document. La riga d'intestazione deve contenere un campo 'email'."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Invia"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Inviare ${item} come newsletter"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "Invia '${context}' attraverso ${channel}."
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Invia come newsletter"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Invia anteprima"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Invia adesso messaggi accodati"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Messaggi inviati"
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Se sei già iscritto ad una delle nostre liste, utilizza questo modulo per recuperare un collegamento alla tua pagina di iscrizione personalizzata:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Visualizza piè di pagina"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Visualizza anteprima"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Configurazione di Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Canale Predefinito"
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Stato"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Iscriviti"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Iscriviti direttamente dal riquadro"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Iscriviti a ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Iscritti"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Iscritti esportati."
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Iscrizioni"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Cancellati con successo i messaggi accodati nelle mailing-list."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Rimossi con successo i vecchi messaggi dalle mailing-list."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Distribuzione pianificata con successo."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr "Modello"
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Testo a piè pagina - se omesso verrà utilizzato il titolo della mailing-list"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Testo da apporre alla fine di ogni messaggio. Qui puoi usare un numero di variabili incluso ${subject}."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Testo da apporre alla fine di ogni messaggio"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "Manca l'indirizzo a cui inviare l'anteprima"
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "Il delimitatore nel file CSV. (Solitamente ',' o ';', ma gli apici non sono necessari.)"
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "L'indirizzo del mittente che apparirà nei messaggi inviati da questo compositore."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "La mailing-list a cui abilitare le iscrizioni."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "La mailing-list attraverso la quale inviare"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "L'indirizzo rispondi-a che apparirà nei messaggi inviati da questo compositore."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Il nome del mittente che apparirà nei messaggi inviati da questa mailing-list."
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "Il foglio di stile verrà applicato al documento."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "Il modello che verrà usato."
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Sembra esserci un errore nelle informazioni che hai inserito."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Ci sono stati alcuni errori."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Questo è richiesto solamente se clicchi di seguito su 'Pianifica distribuzione'"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Questo è richiesto solamente se clicchi di seguito su 'Invia anteprima'"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Questo riquadro permette ad un visitatore di iscriversi ad una newsletter specifica."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Titolo"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Titolo del riquadro renderizzato"
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Per confermare la tua iscrizione a ${channel}, clicca qui: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Totale messaggi inviati"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Numero totale dei messaggi inviati con successo"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Attiva ora"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Digitare"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Cancella iscrizione"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Cancella iscrizione dalla newsletter"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Sù all'amministrazione dei Collettori"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr "Sù all'amministrazione delle Mailing-list"
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Sù alla Configurazione di Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Sù alla Configurazione del Sito"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Carica"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Carica qui un file CSV (Comma Separated Values - Valori Separati da Virgola) con la lista degli iscritti. Gli iscritti già presenti nel database saranno sovrascritti. Ogni linea dovrebbe contenere: ${columns}."
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Carica un elenco degli iscritti."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "Utilizzare una singola pagina del modulo delle iscrizioni"
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "Utilizzare se possibile una singola pagina del modulo delle iscrizioni."
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Ti sei già iscritto/a a questa newsletter. Clicca qui ${link_start} per modificare la tua iscrizione${link_end}."
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Sei già iscritto(a). Compila il form in fondo alla pagina per ricevere un collegamento dal quale poter modificare la tua iscrizione."
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "In questo momento sei iscritto alle seguenti newsletter: "
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Non sei iscritto(a) a questa mailing-list."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr "Non è possibile aggiungere elementi in modalità solo svuota."
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Puoi iscriverti a queste newsletter:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Hai confermato la tua iscrizione con successo."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Qui è possibile usare un certo numero di variabili, quali ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Iscrizione inserita con successo."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Iscrizione cancellata con successo."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr "Ti sei disiscritto correttamente."
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Hai ricevuto questa e-mail poiché sei registrato a ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Il tuo indirizzo e-mail non è valido"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "Il tuo indirizzo email è già stato inserito. Clicca di seguito sul pulsante \"Invia i miei dettagli di iscrizione\"."
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Non abbiamo traccia della tua iscrizione."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "La tua iscrizione è stata aggiornata."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr "Creare, modificare ed eliminare Mailing-list"
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr "Creare, modificare ed eliminare collezioni"
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "Amministrazione Impostazioni Globali"
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Attività delle newsletter in dettaglio."
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Amministrazione delle Mailing-list"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Amministrazione dei collettori"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "Amministrazione Impostazioni newsletter"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr "(Obbligatorio)"
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Statistiche"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr "Obbligatorio"
 

--- a/collective/dancing/locales/nl/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/nl/LC_MESSAGES/collective.dancing.po
@@ -19,911 +19,993 @@ msgstr ""
 "Domain: collective.dancing\n"
 "X-Is-Fallback-For: nl-be nl-nl\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "${channel} opties"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} ondersteunt geen inplannen van taken"
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} inschrijvingen succesvol aangepast!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} inschrijvingen succesvol aangepast, ${numberremoved} verwijderd!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} inschrijvingen succesvol aangepast. ${numberremoved} verwijderd. ${numbernotadded} konden niet toegevoegd worden. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberremoved} inschrijvingen succesvol verwijderd!"
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} bericht(en) in de wachtrij"
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} bericht(en) in de wachtrij"
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} bericht(en) verzonden, ${failed} mislukt."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Mailinglijstportlet toevoegen"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr "Voeg mailinglijsten toe of bewerk ze. Mailinglijsten gebruiken collecties om specifieke stukken informatie van je site te vinden en te e-mailen naar ingeschreven e-mailadressen (abonnees), op gezette tijden."
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Adres om de voorbeeldweergave naartoe te verzenden"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Alle afgeronde taken opgeruimd"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Alle taken in de wachtrij zijn verwerkt"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Alle verzonden en gefaalde berichten verwijderd"
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Al ingeschreven?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Voeg automatisch verzamelde content toe in deze mailing"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Wijzigingen toepassen"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Terug naar portlets"
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Hieronder ziet u een lijst van het nieuwsbrieven-aanbod. Indien u al bent ingeschreven, kunt u het formulier op het einde van deze pagina gebruiken om een link te versturen waarmee u uw bestaande inschrijvingen kunt bewerken."
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Vriendelijke groeten"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS stylesheet"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV bevat een header regel"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "CSV scheidingsteken"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Wijzig uw inschrijving voor ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Ruim afgeronde taken op"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Ruim berichten in de wachtrij op"
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Klik hier om uw inschrijvingen te beheren met titel ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Klik hier om opties van collecties te selecteren die automatisch geactiveerd dienen te worden bij inschrijvingen van deze porlet."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Geef portlet voettekst weer."
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Klik hier om u uit te schrijven."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Composer voor formaat : ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Composers"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Bevestig uw inschrijving op ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Uw inschrijving bevestigen"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Vervangend onderwerp"
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Datum van uitvoering"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Beschrijving van de weergegeven portlet"
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Toon een formulier zodat dit content item als nieuwsletter verstuurd kan worden."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Download"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "E-mailadres"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Wijzig"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Wijzig ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Wijzig ${selector} voor ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr "Wijzig mailinglijst ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Mailinglijstportlet wijzigen"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Wijzig lopende abonnementen"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Wijzig de eigenschappen van de composer."
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "Wijzig de eigenschappen van een mailinglijst."
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Vul hier een eigen onderwerp in voor uw nieuwsbrief. Laat dit leeg om het standaardonderwerp te gebruiken voor de gekozen content en de mailinglijst."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Vul een zoekterm in om content te vinden."
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Fout bij het importeren van het abonneebestand. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Gefaalde berichten"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Bestand heeft incorrect formaat."
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Bestand is niet opgegeven."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Vul het onderstaande formulier in om een e-mail te ontvangen met een link waarmee u uw inschrijvingen kunt wijzigen."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Vul het onderstaande formulier in om u in te schrijven op ${channel}. Let op: dit is voor nieuwe inschrijvingen. Klik hier om ${link_start}uw inschrijvingen te wijzigen${link_end}."
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Mailinglijst zoeken waarop u rechtstreeks inschrijven wilt toelaten"
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Afgeronde taken"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Voettekst"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Van-adres"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Van-naam"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Genereer"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML e-mail"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Openingstekst"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Inclusief items van collectie"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "De informatie over hoe uw inschrijving te bevestigen, is naar u verstuurd."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Item succesvol toegevoegd"
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Item succesvol verwijderd"
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Item succesvol verplaatst"
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Items"
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Titel taak"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Laatste wijziging"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Beheer inschrijvingen of voeg ze toe"
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Beheer uw inschrijvingen"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Onderwerp van e-mail"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "E-mails staan klaar voor verzenden"
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Bericht succesvol verzonden"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Aantal berichten te verzenden in wachtrij"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Berichten met fouten"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Berichten met fouten in de 'opnieuw verzenden' wachtrij"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Blok naar beneden verplaatsen"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Blok naar boven verplaatsen"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Mijn inschrijvingen"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Nieuwe berichten"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Nieuwsbrief"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr "Nieuwsbrieven"
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Geen items gevonden"
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Geen berichten in de wachtrij."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr "Enkel inschrijvers schoonmaken in deze lijst."
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Maar enkele van uw wijzigingen zijn opgeslagen"
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Taken in de wachtrij"
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Bevestig uw inschrijving"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Vul alstublieft een datum in"
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Selecteer alstublieft items om te verwijderen"
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Selecteer alstublieft items met nieuwe berichten om te legen."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr "Selecteer de mailinglijst waarvan je de wachtende e-mailberichten wilt verzenden."
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Portlet beschrijving"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Portlet koptekst"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Voorbeeldweergave"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Ga verder"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Voer taken uit"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "Lijst schoonmaken voor import."
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "Schoonmaken lijst."
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Blok verwijderen"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Verwijder items"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Verwijder oude berichten"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "Verwijder abonnees in deze lijst."
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Reply-to-adres"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Berichten opnieuw proberen"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Wysiwyg tekst"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Opslaan"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Plan verzending in"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Ingeplande tijd"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Zoeken"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Zoek abonnees"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Onderdelen"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Bekijk een voorbeeldweergave van de nieuwbrief in de browser."
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Selecteer dit als u de eerste rij van de csv wil gebruiken om variabelen van het document aan te wijzen. De eerste rij moet één e-mailveld bevatten."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Verzenden"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Verzend ${item} als nieuwsbrief"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "Zendt '${context}' via ${channel}."
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Verstuur als nieuwsbrief"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Voorbeeldweergave verzenden"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Verzend nu de wachtende berichten"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Verzonden berichten"
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Mocht u al ingeschreven zijn op één van onze lijsten, vul dan dit formulier in om een link te ontvangen naar uw persoonlijk inschrijvingspagina."
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Toon voettekst"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Toon voorbeeldweergave"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Singing & Dancing configuratie"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Standaardkanaal"
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Status"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Inschrijven"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Rechtstreeks inschrijven met portlet"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Abonneer op ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Abonnees"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Abonnees geëxporteerd"
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Inschrijvingen"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Wachtende berichten met succes geleegd in mailinglijsten."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Oude berichten met succes verwijderd van mailinglijsten."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Verzending met succes ingepland"
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr "Sjabloon"
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Voettekst - indien leeg, wordt de titel van de mailinglijst gebruikt"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Tekst die aan het begin van elk bericht verschijnt. U kunt hier een aantal variabelen gebruiken, waaronder ${subject}."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Tekst die zal verschijnen aan het einde van ieder bericht"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "Het adres om de preview naar te verzenden ontbreekt."
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "Het scheidingsteken in uw CSV-bestand. (Normaal gesproken ',' of ';', maar aanhalingstekens zijn niet nodig.)"
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "Het van-adres dat zal verschijnen in berichten gezonden vanaf deze composer."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "De mailinglijst om open te stellen voor inschrijvingen."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "Mailinglijst voor verzending"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "Het reply-to-adres dat zal verschijnen in berichten gezonden vanaf deze composer."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "De afzendernaam die zal verschijnen in berichten gezonden vanaf deze mailinglijst."
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "De stylesheet zal worden toegepast op het document."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "De sjabloon die gebruikt zal worden."
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Er zit een fout in de ingevoerde gegevens."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Er is iets misgegaan."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Dit is alleen verplicht als u beneden klikt op 'Plan verzending in'."
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Dit is alleen verplicht indien u klikt op 'Voorbeeldweergave verzenden'"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Deze portlet staat bezoekers toe om zich in te schrijven voor een specifieke nieuwsbrief"
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Titel"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Titel van de weergegeven portlet"
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Om uw inschrijving voor ${channel} te bevestigen, klik hier: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Totaal aantal berichten verzonden"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Totaal aantal berichten succesvol verzonden"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Nu verzenden"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Type"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Uitschrijven"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Abonnement opzeggen"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Naar configuratie van collectie"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr "Naar mailinglijstadministratie"
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Naar Singing and Dancing configuratie"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Naar Website instellingen"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Upload"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Upload een CSV-bestand met een lijst van abonnees hier. Abonnees die al bestaan in de database worden overschreven. Elke regel moet bevatten: ${columns}."
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Upload lijst met abonnees."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "Gebruik enkelvoudig formulier als inschrijvingspagina"
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "Gebruik enkelvoudig formulier als inschrijvingspagina indien mogelijk"
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "U bent al geabonneerd op deze nieuwsbrief. Klik hier om ${link_start}uw inschrijvingen te wijzigen${link_end}."
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "U bent al ingeschreven. Vul het formulier op het einde van deze pagina in om een link te versturen waarmee u uw inschrijving kan bewerken."
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "U bent momenteel ingeschreven op de volgende nieuwsbrieven."
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "U bent niet ingeschreven op deze mailinglijst."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr "Je kan niks toevoegen in enkel schoonmaak modus!"
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "U kunt zich inschrijven op deze nieuwsbrieven:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Uw inschrijving is bevestigd."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "U mag hier een aantal variabelen gebruiken, zoals ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "U bent succesvol ingeschreven."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "U bent succesvol uitgeschreven."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "U ontvangt deze e-mail omdat u ingeschreven bent op de ${channel} nieuwsbrief."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Uw e-mailadres is ongeldig"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "Uw e-mailadres is al geabonneerd. Klik op de knop 'Verstuur mijn inschrijfgegevens' hieronder."
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Uw inschrijving is niet bekend."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Uw abonnement is aangepast."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr "Een mailinglijst is een knooppunt van configuratie. Het doet op zichzelf niets, maar het biedt een aantal componenten aan om te configureren en mee te werken. Het bevat ook de inschrijvingen."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr "Collecties zijn bruikbaar voor automatische nieuwsbrieven. Ze zijn verantwoordelijk voor het samenstellen van een lijst met items om te publiceren."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "Verander een aantal aspecten van hoe Singing & Dancing zich gedraagt."
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Naar configuratie van statistieken"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Configuratie van mailinglijst"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Collectie configuratie"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "Globale instellingen"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr "(Verplicht)"
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Configuratie van statistieken"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr "Verplicht"
 

--- a/collective/dancing/locales/no/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/no/LC_MESSAGES/collective.dancing.po
@@ -14,911 +14,993 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "${channel} innstillinger"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name}  har ikke støtte for planlegging."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} abonnementer oppdatert!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} abonnementer oppdatert, ${numberremoved} fjernet!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} abonnementer oppdatert, ${numberremoved} fjernet. ${numbernotadded} kunne ikke legges til. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberremoved} abonnementer fjernet!"
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} meldinger lagt til kø."
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} melding(er) lagt til kø."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} melding(er) sendt, ${failed} feil."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Legg til"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Legg til Abonner-infoboks"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr "Legg til eller rediger postlister som skal bruke Samlinger til sende spesifikke sett av document fra nettstedet till abonnerte e-postadresser, på fastsatte tider."
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Adresse for å sende forhåndsvisningen til"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Alle ferdige jobber ryddet"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Alle ventende jobber behandlet"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Alle sendte og feilde medlinger slettet"
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Allerede abonnert?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Legg automatisk innsamlet innholdet i denne sending"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Appliser"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Appliser endringer"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Tilbake til infobokser"
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Nedenfor ser du en liste over nyhetsbrev vi tilbyr. Hvis du allerede abonnerer på noen av disse du kan fylle ut skjemaet på slutten av denne siden skal sendes en link til hvor du kan redigere eksisterende abonnement."
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Vennlig hilsen"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS Stylesheet"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV inneholder en overskriftsrad"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "CSV delimiter"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Endre dine abonnementer hos ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Rydd ferdige jobb"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Rydd medlinger i kø"
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Klikk her for å administrere abonnementene hos ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Klikk her for å velge vilke samlings-alternativer som skal aktiveres automatisk, når du abonnerer fra infoboksen."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Klikk her for å vise bunnteksten i infoboksen."
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Klikk her for å si opp abonnementet."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Komponist for format: ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Komponister"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Bekreft abonnementet for ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Bekrefter abonnementet"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Tilpasset Emne"
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Dato for gjennomføring"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Beskrivelse av gjengitte infoboksen"
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Viser et skjema som lar deg sende dette innholdet elementet som et nyhetsbrev."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Nedlasting"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "E-postadresse"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Rediger"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Rediger ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Rediger ${selector} for ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr "Rediger postliste ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Rediger Abonner-infobox"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Redigere eksisterende abonnement"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Redigere egenskapene for komponisten."
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "Redigere egenskapene for postlisten."
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Angi en egendefinert emne for nyhetsbrevet her. Om tomt brukes standard emnet for den valgte innhold og postliste."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Angi et søk for å finne innhold."
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Feil under importering av abonnent fil. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Klarte meldinger"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Fil har feil format."
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Ingen fil ble angitt"
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Fyll ut skjemaet nedenfor for å motta en e-post med en link som du kan bruke før att redigere dine abonnement."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Fyll ut skjemaet nedenfor for å abonnere på ${channel}. Vær oppmerksom på at dette er for nye abonnementer. Klikk her for å ${link_start}endre dine abonnement${link_end}."
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Finn den postlisten du vil aktivere direkte abonnement på"
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Ferdige jobber"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Bunntekst"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Fra-adresse"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Fra-navn"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Generer"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML E-post"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Topptekst"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Inkluder samlingselementer"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Informasjon om hvordan du bekrefte abonnementet er blitt sendt til deg."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Post lagt til."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Post slettet."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Post flyttet."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Poster"
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Jobbtitel"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Siste Endring"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Administrer eller legg til abonnement."
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Administrer dine abonnementer"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Meldingsemne"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Meldinger i kø for levering."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Meldinger sendt"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Meldinger som venter på å bli sendt"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Meldinger med feil"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Meldinger med feil i kø før å prøve på nytt"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Flytt blokk ned"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Flytt blokk opp"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Mine abonnementer"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Nye meldinger"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Nyhetsbrev"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr "Nyhetsbrev"
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Ingen poster funnet"
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Ingen meldinger i kø."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr "Bare rydde abonnenter i denne listen."
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Bare noen av endringene ble lagret"
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Jobber som venter"
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Vennligst bekreft din påmelding"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Vennligst fyll ut en dato."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Velg poster å fjerne."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Vennligst velg poster med nye meldinger å rydde."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr "Velg hvilken postlistes kø du vil sende."
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Infoboksbeskrivelse"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Infobokstopptekst"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Forhåndsvisning"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Fortsett"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Prosess jobber"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "Rydd listen før import."
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "Rydd liste."
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Fjern blokk"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Fjern oppføringer"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Fjern gamle meldinger"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "Fjern abonnenter i listen."
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Svar til-adresse"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Prøv meldinger på nytt"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Fulltekst"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Lagre"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Planlegg distribusjon"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Planlagt tid"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Søk"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Søk abonnenter"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Deler"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Se en forhåndsvisning av nyhetsbrevet."
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Velg dette hvis du vil bruke CSV overskriftsraden å utpeke variabler. Overskriftsraden må inneholde ett felt med navn 'email'."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Send"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Send ${item} som nyhetsbrev"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "Send '${context}' gjennom ${channel}."
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Send som nyhetsbrev"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Send forhåndsvisning"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Send meldinger i køen nå"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Sendte meldinger"
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Skulle du være abonnerer allerede på en av våre lister, kan du bruke dette skjemaet til å hente en link til din personlige abonnementet siden:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Vis bunntekst"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Vis forhåndsvisning"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Singing & Dancing konfigurasjon"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Standardpostliste"
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Status"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Abonner"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Abonner direkte fra portlet"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Abboner på ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Abonnenter"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Abonnenter eksportert."
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Abonnement"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Ryddet kø meldinger i postlister."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Rydder gamle meldinger fra postlister."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Distribusjon planlagt."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr "Mal"
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Bunntekst - hvis utelatt brukes postlistetittelen"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Tekst som vises i begynnelsen av hver melding. Du kan bruke en rekke variabler her, inkludert ${subject}."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Tekst som vises på slutten av hver melding"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "Adressen å sende forhåndsvisningen til mangler."
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "Skilletegnen i CSV-filen. (Vanligvis ',' eller ';', men ingen anførselstegn er nødvendig.)"
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "Fra adressen som vises i meldinger sendt fra denne postlisten."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Postlisten for å aktivere abonnement på."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "Postlisten att sende dette gjennom"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "Svar til-adresse som skal vises i meldinger sendt fra denne postlisten."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Avsenderen navnet som vil vises i meldinger sendt fra denne postlisten."
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "Stilarket vil bli brukt på dokumentet."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "Malen som skal brukes."
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Det synes å være en feil med informasjonen du har angitt."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Det var noen feil."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "This is only required if you click 'Planlegg distribusjon' nedenfor"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "This is only required if you click 'Send forhåndsvisning' nedenfor"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Denne infoboksen tillater en besøkende å abonnere på en bestemt nyhetsbrev."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Tittel"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Tittel på gjengitte infoboksen"
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "For å bekrefte abonnementet med ${channel}, vennligst klikk her: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Totalt antall meldinger sendt"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Totalt antall meldinger sendt"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Trigger nå"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Type"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Avslutt abonnement"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Avslutt abonnement på nyhetsbrev"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Opp til administrasjon av Samlinger"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr "Opp til postlisteadministrasjon"
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Opp til administrasjon av Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Opp til Plone-oppsett"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Last opp"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Last opp en CSV-fil med en liste over abonnenter her. Abonnenter som allerede finnes i databasen vil bli overskrevet. Hver linje skal inneholde ${columns}."
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Last opp liste over abonnenter."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "Bruk ett enkelt abonnement-skjema"
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "Bruk ett enkelt abonnement-skjema når det er mulig."
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Du abonnerer allerede på dette nyhetsbrevet. Klikk her for å ${link_start}endre dine abonnement${link_end}."
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Du er allerede abonnerer. Fyll ut skjemaet på slutten av denne siden skal sendes en link hvor du kan redigere din påmelding."
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Du abonnerer for tiden på disse nyhetsbrevene:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Du abonnerer ikke på denne postlisten."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr "Du kan ikke legge til ting i rydd-modus!"
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Du kan abonnere på disse nyhetsbrev:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Du har bekreftet din påmelding."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Du kan bruke en rekke variabler her, som ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Du abonnerer nå på nyhetsbrevet."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Du abonnerer nå ikke lenger på nyhetsbrevet."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Du mottar denne e-posten fordi du er registrert for nyhetsbrevet ${channel}"
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Din e-postadresse er ugyldig"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "Din e-postadresse er allerede abonnerer. Klikk på 'Send mine abonnent-detaljer' knappen under."
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Abonnementet er ikke kjent for oss."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Abonnementet ble oppdatert."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr "En postliste er et knutepunkt for konfigurasjon. Det trenger ikke gjøre noe av seg selv. Snarere gir det en rekke komponenter for å konfigurere og arbeide med. Det er også beholderen av abonnement til det."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr "Samlinger er nyttige for automatisk nyhetsbrev. De er ansvarlig for å sette sammen en liste over elementer for publisering."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "Endre noen aspekter av hvordan Singing & Dancing oppfører seg."
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Vis nyhetsbrev statistikk"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Postliste-administrasjon"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Samlinger-administrasjon"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "Globale innstillinger"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr "(Obligatorisk)"
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Statistikk"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr "Nødvendig"
 

--- a/collective/dancing/locales/pl/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/pl/LC_MESSAGES/collective.dancing.po
@@ -17,883 +17,965 @@ msgstr ""
 "Language: pl\n"
 
 #. Default: "channel"
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "Opcje dla kanału ${channel}"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} nie wspiera harmonogramów."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} subskrybcji zostało pomoślnie zaktualizowanych!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} zostało pomyślnie zaktualizowanych, ${numberremoved} zostało usuniętych!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} zostało pomyślnie zaktualizowanych. ${numberremoved} usuniętych. ${numbernotadded} nie może zostać dodanych. (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberremoved} zostało usuniętych!"
 
 #. Default: ""
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} zakolejkowanych wiadomości."
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} wiadomości zakolejkowanych."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} wiadomości wysłanych, ${failed} widomości nie udało się wysłać."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Dodaj"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Dodaj portlet subskrybcji kanałów"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr "Dodaj element do ${title}"
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr "Dodawanie lub edycja list mailingowych, które zostaną wykorzystane do kolekcjonowania informacji z serwisu, na zapisane adresy e-mailowe, w zaplanowanym czasie."
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Adres, na który ma być wysłany podgląd"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Wszystkie zakończone prace zostały wyczyszczone"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Wszystkie oczekujące prace zostały wykonane."
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Usunięto wszystkie wysłane i niewysłane wiadomości"
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Już zapisany?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Dodaj automatycznie zebrane treści w tej wysyłce"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Zastosuj zmiany"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Powrót do portletów"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Poniżej możesz zobaczyć listę oferowanych przez nas newsletterów. Jeśli jesteś już zapisany do niektórych z nich, możesz wypełnić formularz na dole tej strony aby otrzymać link, pod którym możesz edytować swoje subskrypcje."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Z poważaniem"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "Style CSS"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV zawiera nagłówek"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "Ogranicznik CSV"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr "Nie udało się potwierdzić Twojej subskrypcji. Proszę sprawdzić adres URL."
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Zmień swoje subskrybcje ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Wyczyść zakończone prace"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Wyczyść skolejkowane wiadomości"
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Kliknij tutaj aby zarządzać swoimi subskrybcjami ${site_title}:"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Kliknij tutaj, aby opcje kolektora były automatycznie włączone podczas zapisywania z tego portletu."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Kliknij tutaj aby wyświetlać stopkę portletu."
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Jeśli nie chcesz już otrzymywać listów z tej subskrypcji kliknij tutaj."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr "Kolekcja dla ${title}"
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr "Kolekcja: ${title}"
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr "Blok kolekcjonera"
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr "Blok kolekcjonera: ${title}"
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Format komopozytora : ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Kompozytory"
 
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
 #. Default: "channel-title"
-#: ./composer.py:357
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Potwierdź subskrybcję ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Zatwierdzanie Twoich subskrybcji"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr "Wybór treści"
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Temat"
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Data wykonania"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Opis wyświetlanego portletu"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Wyświetla formularz, pozwalający na wysłanie tego elementu treści jako newslettera."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Pobieranie plików"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Adres e-mail"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Edycja"
 
 #. Default: ""
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Edytuj ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Edycja ${selector} dla ${channel}"
 
 #. Default: "channel"
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr "Edytuj kanał ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Edytuj portlet subskrybcji kanału"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Edytuj istniejące subskrybcje"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr "Edycja Zbioru"
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Edycja właściowości kompozytora."
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "Edycja właściwości listy mailingowej."
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Wprowadź linie tytułową dla swojego newslettera. Zostaw pustą aby używać domyślnego tematu dla wybranych treści i listy mailingowej."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Wprowadź wyszukiwaną frazę aby znaleźć treść."
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Błąd importu pliku. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Wiadomości, których wysłanie się nie powiodło "
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "Niepoprawny format pliku."
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Plik nie został załadowany."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Wypełnij poniższy formularz aby otrzymać e-mail z odnośnikiem z którego będziesz mógł edytować swoją subskrybcję."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Wypełnij poniższy formularz aby zapisać się do ${channel} (dla nowych subskrybcji). Kliknij tutaj aby ${link_start}edytować aktywną subskrybcję${link_end}."
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Wybierz kanał, dla którego chcesz uruchomić bezpośrednią subskrybcję"
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Zakończone prace."
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Tekst stopki"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Adres formularza"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Nazwa formularza"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Generuj"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML E-Mail"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Tekst nagłówka"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Dołącz elementy kolekcjonera"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "Informacja na temat sposobu, w jaki potwierdzić subskrybcję została do Ciebie wysłana."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Dodano element."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Usunięto element."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Przeniesiono element."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Pozycje"
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Tytuł zadania"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Ostatnia zmiana"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr "Ostatnie aktualności"
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Zarządzanie i dodawanie subskrybcji."
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Zarządzaj swoimi subskrybcjami"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Temat wiadomości"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Wiadomość oczekuje na wysłanie."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Wiadomości wysłane z powodzeniem"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Wiadomości oczekujące na wysłanie"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Wiadomości z błędami"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Wiadomości z błędami we wznowionej kolejce"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Przenieś blok na dół"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Przenieś blok do góry"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr "Musi być referencją (jest ${title})"
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Moje subskrybcje"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Nowe wiadomości"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Newsletter"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr "Newslettery"
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Nie znaleziono żadnych elementów."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Brak zakolejkowanych wiadomości."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr "Prezentowani subskrybenci prezentowani na liście."
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Tylko niektóre z Twoich zmian zostały zapisane"
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Oczekujące zadania."
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Proszę potwierdzić swoją subskrybcję"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Uzupełnij datę"
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Proszę zaznaczyć pozycje do usunięcia."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Proszę wybrać pozycje z nowymi wiadomościami do wyczyszczenia."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr "Proszę zaznaczyć które wiadomości z listy chciałbyś wysłać."
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Opis portletu"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Nagłówek portletu"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Podgląd"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Kontynuuj"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Wykonaj zadania"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "Wyczyść listę przed importem"
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "Wyczyść listę"
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Usuń blok"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Usuń wpisy"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Usuń stare wiadomości"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "Usuń subskrybentów z listy"
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Odpowiedz na adres"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Wznów wiadomości"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Tekst sformatowany"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr "Tekst formatowany: ${title}"
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Zapisz"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Zaplanuj dystrybucję"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Zaplanowany czas"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Szukaj"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Szukaj subskrybentów"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Kategorie"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Zobacz podgląd newslettera w przeglądarce."
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Zaznacz tą opcję jeżeli chcesz używać wiersza nagłówka csv do przypisywania zmiennych dokumentu. Wiersz nagłówka musi zawierać jedno pole 'email'."
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Wyślij"
 
 #. Default: ""
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Wyślij ${item} jako newsletter"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "Wyślij  '${context}' przez ${channel}."
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Wyślij jako newsletter"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Wyślij podgląd"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Wyślij skolejkowane wiadomości"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Wysłane wiadomości"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Jeśli jesteś już zapisany do jednej z naszych list, skorzystaj z tego formularza aby pobrać link do Twojej spersonalizowanej strony subskrypcji:"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Wyświetlaj stopkę"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Pokaż podgląd"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Konfiguracja Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Kanał standardowy"
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Status"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Subskrybuj"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Subskrybuj bezpośrednio z portletu"
 
 #. Default: "channel"
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Subskrybuj ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Subskrybenci"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Subskrybenci wyeksportowani"
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Subskrybcje"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Pomyślnie wyczyszczono skolejkowane wiadomości na liście mailingowej."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Stare wiadomości zostały pomyślnie usunięte z listy mailingowej."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Dystrybucja została zaplanowana pomyślnie."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr "Szablon"
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Tekst w stopce - w przypadku pustego pola użyty zostanie tytuł kanału"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Tekst który pojawi się na początku każdej wiadomości. Możesz tutaj używać zmiennych jak np. ${subject}."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Tekst "
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "Brak adresu na który ma zostać wysłanany podgląd wiadomości."
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "Ogranicznik w Towim pliku CSV. (Przeważnie ',' lub ';' - bez cudzysłowów)."
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "Adres nadawcy który pojawi się w wiadomościach wysłanych z tego kompozytora."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "Kanał dla którego umożliwić subskrybcje."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "Kanał, którym ma to być wysłane"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "Adres 'odpowiedz do',  który pojawi się w wiadomościach wysłanych z tego kompozytora."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Imię nadawcy które pojawi się wiadomościach wysłanych z tej listy."
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "Style zostaną załadowane do dokumentu."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "Szablon który zostanie wykorzystany."
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Wydaje się, że istnieje błąd we wprowadzonych informacjach."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Wystąpiły pewne błędy. "
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Ta opcja jest wymagana jeżeli klikniesz 'Zaplanuj dystrybucję' poniżej"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Wymagane tylko, jeśli kliniesz przycistk 'Wyślij podgląd' poniżej"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Ten portlet pozwala odwiedzającemu zapisać się do określonego kanału newsletter'a."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Tytuł"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Tytuł wyświetlanego portletu"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Aby potwierdzić subskrypcję ${channel}, proszę kliknąć w link: ${url} "
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Suma wysłanych wiadomości"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Suma wiadomości wysłanych z powodzeniem"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Uruchom teraz"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Typ"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Usuń subskrybcję"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Zrezygnuj z newslettera"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Do administracji kolekcjonera"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr "Wyżej do administracji listami mailingowymi"
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Do konfiguracji Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Do ustawień strony"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Załaduj"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Załaduj plik CSV z listą subskrybentów. Subskrybenci obecni w bazie danych zostaną nadpisani. Każda linia powinna zawierać: ${columns}."
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Załaduj listę subskrybentów."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "Używaj wersji strony z pojedynczym formularzem."
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "Używaj wersji strony z pojedynczym formularzem kiedy możliwe."
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "Jesteś już zapisany do tego newslettera. Kliknij tutaj aby ${link_start}edytować subskrybcję${link_end}."
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Jesteś już zarejestrowany. Wypełnij formularz na dole tej strony aby otrzymać link, z którego będziesz mógł edytować swoją subskrypcję."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Aktualnie subskrybujesz następujące newslettery:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Nie jesteś zapisany do tego kanału."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr "Elementy nie mogą zostać dodane w tym trybie."
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Możesz subskrybować następujące newslettery:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Potwierdziłeś pomyślnie swoją subskrybcję."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Można wykorzystać zmienne jak ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Twoja rejestracja zakończyła się pomyślnie."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Usunięto Twoją subskrybcję."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Otrzymujesz ten e-mail ponieważ jesteś zarejestrowany na newsletter ${channel}"
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Twój adres e-mail jest nieprawidłowy"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "Twój adres e-mail jest już zapisany. Kliknij 'Wyślij szczegóły mojej subskrybcji' poniżej."
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Twoja subskrybcja nie jest nam znana."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Twoja subskrybcja została zaktualizowana."
 
@@ -901,60 +983,60 @@ msgstr "Twoja subskrybcja została zaktualizowana."
 # "        itself.  Rather, it provides a number of components to configure\n"
 # "        and work with.  It is also the container of subscriptions to it."
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr "Kanał to twór służący do przechowywania konfiguracji. Sam z siebie nie posiada żadnej funkcji, ale umożliwia stosowanie różnych ustawień wysyłania wiadomości dla różnych grup subskrybentów. "
 
 # "Collectors are useful for automatic newsletters.  They are\n"
 # "      responsible for assembling a list of items for publishing."
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr ""
 "Kolekcjonery są przydatne dla automatycznych newsletterów.\n"
 " Są odpowiedzialne za zbieranie listy artykułów do publikacji."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "Zmienia kilka zachowań systemu Singing & Dancing."
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Zobacz statystyki newslettera"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "Administracja kanału"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Administracja kolekcjonera"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "Administracja ustawień newlettera"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr "Wymagana etykieta"
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Statystyka"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr "Wymagany tytuł"
 

--- a/collective/dancing/locales/pt_BR/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/pt_BR/LC_MESSAGES/collective.dancing.po
@@ -14,948 +14,1030 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "Opções para ${channel}"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name} não suporta agendamento."
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded} assinaturas atualizadas com sucesso!"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} assinaturas atualizadas com sucesso, ${numberremoved} removidas!"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} assinaturas atualizadas com sucesso. ${numberremoved} removidos. ${numbernotadded} não puderam ser adicionados (${errorcandidates})"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} mensagens enfileiradas."
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num} mensagem(ns) enfileirada(s)."
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} mensagem(ns) enviada(s), ${failed} falha(s)."
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "Adicionar"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 #, fuzzy
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "Adicionar portlet de assinatura de canal"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "Endereço para enviar a mensagem de teste"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "Todas as tarefas terminadas."
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "Todas as tarefas pendentes processadas."
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "Todas as mensagens, enviadas e com falhas, apagadas."
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "Já é assinante?"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "Adiciona automaticamente o conteúdo coletado a este envio"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "Aplicar alterações"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "Voltar aos portlets"
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "Abaixo você vê uma lista dos boletins que oferecemos. Caso você esteja cadastrado a alguns deles, preencha o formulário no final desta página para receber uma mensagem com um link para editar suas assinaturas."
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "Att."
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS Stylesheet"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV contém uma linha de cabeçalho"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "Delimitador do CSV"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "Modificar suas assinaturas em ${site_title}"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "Limpar tarefas finalizadas"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "Limpar mensagens enfileiradas"
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "Clique aqui para gerenciar suas assinaturas em ${site_title}"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "Clique aqui para habilitar as opções de coleção quando assinadas a partir deste portlet."
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "Clique aqui para exibir o rodapé do portlet."
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "Clique aqui para cancelar a assinatura."
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "Compositor para formato : ${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "Compositores"
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "Confirme sua assinatura de ${channel-title}"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "Confirmando sua assinatura"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "Assunto personalizado"
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "Data de execução"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "Descrição do portlet renderizado"
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "Exibe um formulário que permite enviar este conteúdo como um boletim."
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "Baixar"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "Endereço de e-mail"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "Editar"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "Editar ${collector}"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "Editar ${selector} para ${channel}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 #, fuzzy
 msgid "Edit Mailing-list ${channel}"
 msgstr "Editar o canal ${channel}"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 #, fuzzy
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "Editar o portlet de assinatura de canal"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "Editar assinaturas existentes"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "Editar as propriedades do compositor."
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 #, fuzzy
 msgid "Edit the properties of the mailing-list."
 msgstr "Editar as propriedades deste canal."
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 #, fuzzy
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "Informe o assunto para o seu boletim aqui. Deixe em branco para que seja utilizado o assunto padrão para este conteúdo e canal."
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "Digite a busca personalizada para buscar o conteúdo."
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "Erro ao importar o arquivo de assinantes. %s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "Mensagens com falhas"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "O arquivo está com formato incorreto."
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "Arquivo não informado."
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "Preencha o formulário abaixo para receber um email com o link a partir do qual você poderá editar suas assinaturas."
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 #, fuzzy
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "Encontre o canal que você quer habilitar a assinatura diretamente"
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "Tarefas concluídas"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "Texto do rodapé"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "Endereço do remetente"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "Nome do remetente"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "Gerar"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "E-mail HTML"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "Cabeçalho"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "Incluir itens da coleção"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "A explicação sobre como confirmar sua assinatura foi enviada para você."
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "Item adicionado com sucesso."
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "Item removido com sucesso."
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "Item movido com sucesso."
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "Itens"
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "Título da tarefa"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "Última alteração"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "Gerencie ou adicione assinaturas."
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "Gerencie suas assinaturas"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "Assunto da mensagem"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "Mensagens enfileiradas para entrega."
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "Mensagens enviadas de maneira bem sucedida"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "Mensagens aguardando para ser enviadas"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "Mensagens com erros"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "Mensagens com erros na fila de re-envio"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "Move o bloco para baixo"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "Move o block para cima"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "Minhas asinaturas"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "Novas mensagens"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "Boletim"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "Nenhum item encontrado."
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "Nenhuma mensagem enfileirada."
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "Apenas algumas das suas modificações foram salvas."
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "Tarefas pendentes"
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "Por favor confirme sua assinatura"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "Por favor informe uma data."
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "Por favor selecione os itens a serem removidos."
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "Por favor selecione os itens com novas mensagens a serem apagadas."
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "Descrição do portlet"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "Cabeçalho do portlet"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "Prosseguir"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "Processar tarefas"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "Remover o bloco"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "Remover as entradas"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "Remover mensagens antigas"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "Endereço de resposta"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "Mensagens para reenvio"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "Texto rico"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "Salvar"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "Distribuição agendada"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "Horário de agendamento"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "Buscar"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "Buscar assinantes"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "Seções"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "Visualizar uma previsão do boletim em seu navegador"
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "Clique aqui caso você queria designar o cabeçalho do csv como variáveis do documento. O cabeçalho dever conter ao menos um campo 'email'"
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "Enviar"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "Enviar ${item} como boletim"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "Enviar como boletim"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "Enviar previsão"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "Enviar mensagens enfileiradas agora"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "Enviar mensagens"
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "Caso você já esteja assinando um de nossos boletins, por favor utilize este formulário para recuperar um link para a sua página de assinaturas."
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "Exibir rodapé"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "Exibir previsão"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "Configuração do Singing & Dancing"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "Canal padrão"
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "Estado"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Assinar"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "Assinar diretamente do portlet"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "Assinar ${channel}"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "Assinantes"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "Assinantes exportados."
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "Assinaturas"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 #, fuzzy
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "Fila de mensagens nos canais apagada de maneira bem sucedida."
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 #, fuzzy
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "Mensagens antigas removidas de maneira bem sucedida."
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "Distribuição agendada de maneira bem sucedida."
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 #, fuzzy
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "Texto no rodapé - caso omitido o título do canal será utilizado"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "Texto a ser exibido no início de cada mensagem. Você pode utilizar variáveis incluindo ${subject} para assunto."
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "Texto a ser exibido no final de cada mensagem"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "O delimitador no seu arquivo CSV (Usualmente ',' ou ';')"
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "O endereço que será utilizado nas mensagens enviadas a partir deste compositor."
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 #, fuzzy
 msgid "The mailing-list to enable subscriptions to."
 msgstr "O canal para habilitar as assinaturas."
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 #, fuzzy
 msgid "The mailing-list to send this through"
 msgstr "O canal a ser utilizado para envio."
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "O endereço de resposta que será utilizado nas mensagens enviadas a partir deste compositor."
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 #, fuzzy
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "Nome do remetente que será utilizado nas mensagens enviadas a partir deste compositor"
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "A folha de estilos será aplicada a este documento."
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "Parece haver um erro com a informação que você digitou."
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "Ocorreram alguns erros."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "Apenas necessário caso você selecione 'Distribuição agendada' abaixo"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "Apenas necessário caso você selecione 'Enviar previsão' abaixo"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 #, fuzzy
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "Este portlet permite ao visitante assinar um boletim específico."
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "Título"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "Título do portlet"
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "Para confirmar sua assinatura ${channel}, por favor clique aqui: ${url}"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "Total de mensagens enviadas"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "Número de mensagens enviadas com sucesso"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "Disparar agora"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "Tipo"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "Cancelar assinatura"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "Cancelar assinatura do boletm"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "Voltar à administração de coleções"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "Voltar à configuração do Singing & Dancing"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "Voltar às configurações do site"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "Enviar arquivo"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "Enviar arquivo CSV com a lista de assinantes. Assinantes já existentes na base de dados serão sobreescritos. Cada linha deve conter: ${columns}"
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "Enviar lista de assinantes."
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "Você já está cadastrado. Preencha o formulário no final desta página para receber um link para editar sua assinatura."
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "Você atualmente assina estes boletins:"
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 #, fuzzy
 msgid "You aren't subscribed to this mailing-list."
 msgstr "Você não assina este canal."
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "Você pode assinar os seguintes boletins:"
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "Você confirmou sua assinatura."
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "Você pode usar diversas variáveis aqui, como ${site_title}."
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "Assinatura bem sucedida."
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "Cancelamento realizado."
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "Você recebe este e-mail por estar registrado no boletim ${channel}."
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "Seu endereço de e-mail é inválido"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "Sua assinatura não consta em nosso cadastro."
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "Sua assinatura foi atualizada."
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 #, fuzzy
 msgid "description_channel_administration"
 msgstr "Um canal é uma central de configurações. Ele não realiza nenhuma tarefa sozinho. Ao invés disto ele provê uma série de componentes para serem configurados. Também atua como o armazenador das assinaturas."
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 #, fuzzy
 msgid "description_collector_administration"
 msgstr "Coleções são úteis para envio de boletins automáticos. Eles são responsáveis pela montagem de uma lista de itens para publicação."
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "Visualizar as estatísticas do boletim."
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 #, fuzzy
 msgid "label_channel_administration"
 msgstr "Administração de canais."
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "Administração de coleções."
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "Estatísticas"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/rebuild.sh
+++ b/collective/dancing/locales/rebuild.sh
@@ -1,4 +1,4 @@
-i18ndude rebuild-pot --pot ./collective.dancing.pot --merge collective.dancing-manual.pot --create collective.dancing ../templates || exit 1
+i18ndude rebuild-pot --pot ./collective.dancing.pot --merge collective.dancing-manual.pot --create collective.dancing .. || exit 1
 i18ndude sync --pot ./collective.dancing.pot ./*/LC_MESSAGES/collective.dancing.po
 
 ERRORS=`find ../ -name "*pt" | xargs i18ndude find-untranslated | grep -e '^-ERROR' | wc -l`
@@ -9,8 +9,8 @@ echo
 echo "There are $ERRORS errors \(almost definitely missing i18n markup\)"
 echo "There are $WARNINGS warnings \(possibly missing i18n markup\)"
 echo "There are $FATAL fatal errors \(template could not be parsed, eg. if it\'s not html\)"
-echo "For more details, run \'find . -name \"\*pt\" \| xargs i18ndude find-untranslated\' or" 
-echo "Look the rebuild i18n log generate for this script called \'rebuild_i18n.log\' on locales dir" 
+echo "For more details, run \'find . -name \"\*pt\" \| xargs i18ndude find-untranslated\' or"
+echo "Look the rebuild i18n log generate for this script called \'rebuild_i18n.log\' on locales dir"
 
 rm ./rebuild_i18n.log
 touch ./rebuild_i18n.log

--- a/collective/dancing/locales/sv/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/sv/LC_MESSAGES/collective.dancing.po
@@ -1,7 +1,7 @@
 # translation of collective.dancing.
 # <kevin.samuel@pilotsystems.net>, 2008.
-# 
-# 
+#
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.dancing 0.1\n"
@@ -19,931 +19,1013 @@ msgstr ""
 "Domain: collective.dancing\n"
 "Report-Msgid-Bugs-To: \n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr ""
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr ""
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr ""
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr ""
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr ""
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr ""
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr ""
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr ""
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr ""
 
 #. Default: "Already subscribed?"
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr ""
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr ""
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr ""
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr ""
 
 #. Default: "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr ""
 
 #. Default: "Best regards"
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr ""
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr ""
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr ""
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
 #. Default: "Change your subscriptions with ${site_title}"
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr ""
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr ""
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr ""
 
 #. Default: "Click here to manage your subscriptions with ${site_title}:"
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr ""
 
 #. Default: "Click here to unsubscribe."
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr ""
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr ""
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr ""
 
-#: ./composer.py:357
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr ""
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr ""
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr ""
 
 #. Default: "Date of execution"
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr ""
 
 #. Default: "Displays a form that lets you send this content item as a newsletter."
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr ""
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr ""
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "E-postadress"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr ""
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr ""
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr ""
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr ""
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr ""
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr ""
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr ""
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr ""
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr ""
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr ""
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr ""
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr ""
 
 #. Default: "Finished jobs"
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr ""
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr ""
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr ""
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr ""
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr ""
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr ""
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr ""
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr ""
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr ""
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr ""
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr ""
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr ""
 
 #. Default: "Job title"
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr ""
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr ""
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr ""
 
 #. Default: "Manage your subscriptions"
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr ""
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr ""
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr ""
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr ""
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr ""
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr ""
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr ""
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr ""
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr ""
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr ""
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr ""
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr ""
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr ""
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr ""
 
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
 #. Default: "Pending jobs"
-#: ./browser/jobs.pt:9
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr ""
 
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
 #. Default: "Please confirm your subscription"
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr ""
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr ""
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr ""
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr ""
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr ""
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr ""
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr ""
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr ""
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr ""
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr ""
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr ""
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr ""
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr ""
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr ""
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr ""
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr ""
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr ""
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr ""
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr ""
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr ""
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr ""
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr ""
 
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
 #. Default: "Send as newsletter"
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr ""
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr ""
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr ""
 
 #. Default: "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr ""
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr ""
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr ""
 
 #. Default: "Status"
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr ""
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "Prenumerera"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr ""
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr ""
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr ""
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr ""
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr ""
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr ""
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr ""
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr ""
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr ""
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr ""
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr ""
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr ""
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr ""
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr ""
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr ""
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr ""
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr ""
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr ""
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr ""
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr ""
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr ""
 
 #. Default: "To confirm your subscription with ${channel}, please click here: ${url}"
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr ""
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr ""
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr ""
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr ""
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr ""
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr ""
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr ""
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr ""
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr ""
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr ""
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr ""
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr ""
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr ""
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr ""
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr ""
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr ""
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr ""
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr ""
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr ""
 
 #. Default: "You are currently subscribed to these newsletters:"
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr ""
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr ""
 
 #. Default: "You can subscribe to these newsletters:"
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr ""
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr ""
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr ""
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr ""
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
 #. Default: "You're receiving this e-mail because you're registered for the ${channel} newsletter."
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr ""
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr ""
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr ""
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr ""
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr ""
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr ""
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr ""
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr ""
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr ""
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr ""
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr ""
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr ""
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr ""
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr ""
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr ""
 

--- a/collective/dancing/locales/zh/LC_MESSAGES/collective.dancing.po
+++ b/collective/dancing/locales/zh/LC_MESSAGES/collective.dancing.po
@@ -14,912 +14,994 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/portlets/channelsubscribe.py:292
+#: ../browser/portlets/channelsubscribe.py:292
 msgid "${channel} options"
 msgstr "${channel} 配置选项"
 
-#: ./browser/sendnewsletter.py:129
+#: ../browser/sendnewsletter.py:165
 msgid "${name} does not support scheduling."
 msgstr "${name}不支持调度。"
 
-#: ./browser/channel.py:620
+#: ../browser/channel.py:742
 msgid "${numberadded} subscriptions updated successfully!"
 msgstr "${numberadded}个预订已成功更新！"
 
-#: ./browser/channel.py:614
+#: ../browser/channel.py:736
 msgid "${numberadded} subscriptions updated successfully, ${numberremoved} removed!"
 msgstr "${numberadded} 个预订成功更新，${numberremoved}个删除！"
 
-#: ./browser/channel.py:604
+#: ../browser/channel.py:726
 msgid "${numberadded} subscriptions updated successfully. ${numberremoved} removed. ${numbernotadded} could not be added. (${errorcandidates})"
 msgstr "${numberadded} 个预订成功更新，${numberremoved}个删除，${numbernotadded}个不能添加！（${errorcandidates}）"
 
-#: ./browser/channel.py:601
+#: ../browser/channel.py:723
 msgid "${numberremoved} subscriptions removed successfully!"
 msgstr "${numberremoved}个预订成功删除！"
 
-#: ./browser/scheduler.py:36
+#: ../browser/scheduler.py:36
 msgid "${number} messages queued."
 msgstr "${number} 个邮件在队列中（待发送）。"
 
-#: ./browser/sendnewsletter.py:220
+#: ../browser/sendnewsletter.py:268
 msgid "${num} message(s) queued."
 msgstr "${num}个信息排队中。"
 
-#: ./browser/sendnewsletter.py:77
+#: ../browser/sendnewsletter.py:82
 msgid "${queued} message(s) queued for delivery."
 msgstr ""
 
-#: ./browser/stats.py:118
+#: ../browser/stats.py:118
 msgid "${sent} message(s) sent, ${failed} failure(s)."
 msgstr "${sent} 个消息已发送，${failed}个失败。"
 
-#: ./browser/sendnewsletter.py:66
+#: ../browser/sendnewsletter.py:70
 msgid "0 messages queued for delivery. Item '${newsletter_path}' not found."
 msgstr ""
 
-#: ./browser/collector.py:185
+#: ../contentrules.py:288
+msgid "A S&D Collector condition filters to only items in a collector."
+msgstr ""
+
+#: ../contentrules.py:168
+msgid "A S&D Newsletter action can send an item as a newsletter"
+msgstr ""
+
+#: ../browser/collector.py:185
 msgid "Add"
 msgstr "添加"
 
-#: ./browser/portlets/channelsubscribe.py:455
+#: ../browser/portlets/channelsubscribe.py:455
 msgid "Add Mailing-list Subscribe Portlet"
 msgstr "添加邮件列表预定面板"
 
-#: ./browser/collector.py:167
+#: ../contentrules.py:287
+msgid "Add S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:167
+msgid "Add S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/collector.py:167
 msgid "Add item to ${title}"
 msgstr ""
 
-#: ./browser/channel.py:98
+#: ../browser/channel.py:99
 msgid "Add or edit mailing-lists that will use collectors to gather and email specific sets of information from your site, to subscribed email addresses, at scheduled times."
 msgstr "添加或编辑邮件列表"
 
-#: ./browser/interfaces.py:22
+#: ../browser/interfaces.py:34
 msgid "Address to send the preview to"
 msgstr "发送预览的收件人地址"
 
-#: ./browser/stats.py:146
+#: ../browser/stats.py:146
 msgid "All finished jobs cleared"
 msgstr "所有已完成的作业被清除"
 
-#: ./browser/stats.py:138
+#: ../browser/stats.py:138
 msgid "All pending jobs cleared"
 msgstr ""
 
-#: ./browser/stats.py:130
+#: ../browser/stats.py:130
 msgid "All pending jobs processed"
 msgstr "所有等候作业已处理"
 
-#: ./browser/stats.py:170
+#: ../browser/stats.py:170
 msgid "All sent and failed messages deleted"
 msgstr "所有已发送或发送失败的邮件被删除"
 
-#: ./browser/prettysubscriptions.pt:23
-#: ./browser/subscriptions.pt:33
+#: ../browser/prettysubscriptions.pt:23
+#: ../browser/subscriptions.pt:33
 msgid "Already subscribed?"
 msgstr "已预订了吗？"
 
-#: ./browser/interfaces.py:16
+#: ../browser/interfaces.py:28
 msgid "Append automatically collected content in this send-out"
 msgstr "自动添加已收集的内容到此"
 
-#: ./browser/scheduler.py:26
-#: ./browser/subscribe.py:728
+#: ../browser/scheduler.py:26
+#: ../browser/subscribe.py:741
 msgid "Apply"
 msgstr "应用"
 
-#: ./browser/subscribe.py:209
+#: ../browser/subscribe.py:215
 msgid "Apply changes"
 msgstr "保存更改"
 
-#: ./browser/portlets/channelsubscribe.py:405
+#: ../browser/portlets/channelsubscribe.py:405
 msgid "Back to portlets"
 msgstr "回到控制面板"
 
-#: ./browser/prettysubscriptions.pt:10
-#: ./browser/subscriptions.pt:10
+#: ../browser/prettysubscriptions.pt:10
+#: ../browser/subscriptions.pt:10
 msgid "Below you see a list the newsletters we offer. If you are already subscribed to some of these you can fill out the form at the end of this page to be sent a link to where you can edit your existing subscriptions."
 msgstr "下面是本站提供的邮件预定频道列表。如果你已经预订了其中某些内容，你可以填写下面表单，以便发送一个链接，通过该链接你能编辑已存的预订。"
 
-#: ./browser/composer-html-forgot.pt:30
+#: ../browser/composer-html-forgot.pt:30
 msgid "Best regards"
 msgstr "此致好运！"
 
-#: ./interfaces.py:57
+#: ../interfaces.py:76
 msgid "CSS Stylesheet"
 msgstr "CSS 样式表"
 
-#: ./browser/channel.py:487
+#: ../browser/channel.py:559
 msgid "CSV contains a header row"
 msgstr "CSV 包含一个表头行"
 
-#: ./browser/channel.py:494
+#: ../browser/channel.py:566
 msgid "CSV delimiter"
 msgstr "CSV分割符"
 
-#: ./browser/subscribe.py:122
+#: ../browser/subscribe.py:127
 msgid "Can't identify your subscription. Please check your URL."
 msgstr ""
 
-#: ./browser/composer-html-forgot.pt:16
-#: ./composer.py:383
+#: ../browser/composer-html-forgot.pt:16
+#: ../composer.py:388
 msgid "Change your subscriptions with ${site_title}"
 msgstr "更改${site_title}站点的预定"
 
-#: ./browser/stats.py:140
+#: ../browser/stats.py:140
 msgid "Clear finished jobs"
 msgstr "清除已完成作业"
 
-#: ./browser/stats.py:132
+#: ../browser/stats.py:132
 msgid "Clear pending jobs"
 msgstr ""
 
-#: ./browser/stats.py:98
+#: ../browser/stats.py:98
 msgid "Clear queued messages"
 msgstr "清除队列中的信息"
 
-#: ./browser/composer-html-forgot.pt:21
+#: ../browser/composer-html-forgot.pt:21
 msgid "Click here to manage your subscriptions with ${site_title}:"
 msgstr "点击这儿管理你在${site-title}站点的预订"
 
-#: ./browser/portlets/channelsubscribe.py:45
+#: ../browser/portlets/channelsubscribe.py:45
 msgid "Click here to select collector options to be automatically enabled, when subscribing from this portlet."
 msgstr "从这个面板预订时，点击这儿选择的收集器选项将自动启用。"
 
-#: ./browser/portlets/channelsubscribe.py:53
+#: ../browser/portlets/channelsubscribe.py:53
 msgid "Click here to show the portlet footer."
 msgstr "点击这儿显示控制面板下部"
 
-#: ./browser/composer-html.pt:44
+#: ../browser/composer-html.pt:44
 msgid "Click here to unsubscribe."
 msgstr "点击这儿取消预订"
 
-#: ./collector.py:230
+#: ../collector.py:230
 msgid "Collection for ${title}"
 msgstr ""
 
-#: ./browser/collector.py:101
+#: ../browser/collector.py:101
 msgid "Collection: ${title}"
 msgstr ""
 
-#: ./collector.py:128
+#: ../collector.py:128
 msgid "Collector block"
 msgstr ""
 
-#: ./browser/collector.py:301
+#: ../browser/collector.py:301
 msgid "Collector block: ${title}"
 msgstr ""
 
-#: ./browser/composer.py:38
+#: ../browser/composer.py:38
 msgid "Composer for format : ${format}"
 msgstr "组成格式：${format}"
 
-#: ./browser/channel.py:755
+#: ../browser/channel.py:877
 msgid "Composers"
 msgstr "构造器"
 
+#: ../contentrules.py:169
+msgid "Configure element"
+msgstr ""
+
 #. Default: "channel-title"
-#: ./composer.py:357
+#: ../composer.py:362
 msgid "Confirm your subscription with ${channel-title}"
 msgstr "请确认您预定的快报频道"
 
-#: ./browser/subscribe.py:102
+#: ../browser/subscribe.py:106
 msgid "Confirming your subscription"
 msgstr "确认您的预订"
 
-#: ./collector.py:96
+#: ../contentrules.py:149
+msgid "Content rule send \"${context}\" through ${channel}."
+msgstr ""
+
+#: ../collector.py:96
 msgid "Content selection"
 msgstr ""
 
-#: ./browser/sendnewsletter.py:276
+#: ../browser/sendnewsletter.py:324
 msgid "Custom Subject"
 msgstr "定制的主题"
 
-#: ./browser/jobs.pt:25
+#: ../browser/jobs.pt:25
 msgid "Date of execution"
 msgstr "执行日期"
 
-#: ./browser/portlets/channelsubscribe.py:42
+#: ../browser/portlets/channelsubscribe.py:42
 msgid "Description of the rendered portlet"
 msgstr "呈现面板的描述"
 
-#: ./profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Displays a form that lets you send this content item as a newsletter."
 msgstr "显示一个让你发送内容作为快报的表单。"
 
-#: ./browser/channel.py:644
+#: ../browser/channel.py:766
 msgid "Download"
 msgstr "下载"
 
-#: ./composer.py:131
+#: ../composer.py:133
 msgid "E-mail address"
 msgstr "邮件地址"
 
-#: ./browser/channel.py:754
+#: ../browser/channel.py:876
 msgid "Edit"
 msgstr "編輯"
 
-#: ./browser/collector.py:333
+#: ../browser/collector.py:333
 msgid "Edit ${collector}"
 msgstr "编辑${collector}收集器"
 
-#: ./browser/scheduler.py:93
+#: ../browser/scheduler.py:93
 msgid "Edit ${selector} for ${channel}"
 msgstr "为${channel}频道编辑${selector}"
 
-#: ./browser/channel.py:730
+#: ../browser/channel.py:852
 msgid "Edit Mailing-list ${channel}"
 msgstr "编辑${channel}邮件列表"
 
-#: ./browser/portlets/channelsubscribe.py:374
+#: ../browser/portlets/channelsubscribe.py:374
 msgid "Edit Mailing-list Subscribe Portlet"
 msgstr "编辑邮件列表预定面板"
 
-#: ./browser/subscribe.py:43
+#: ../contentrules.py:302
+msgid "Edit S&D Collector Condition"
+msgstr ""
+
+#: ../contentrules.py:182
+msgid "Edit S&D Newsletter Action"
+msgstr ""
+
+#: ../browser/subscribe.py:47
 msgid "Edit existing subscriptions"
 msgstr "编辑现有的预订"
 
-#: ./browser/collector.py:107
+#: ../browser/collector.py:107
 msgid "Edit the Smart Folder"
 msgstr ""
 
-#: ./browser/composer.py:29
+#: ../browser/composer.py:29
 msgid "Edit the properties of the composer."
 msgstr "编辑这个构造器参数"
 
-#: ./browser/channel.py:361
+#: ../browser/channel.py:362
 msgid "Edit the properties of the mailing-list."
 msgstr "编辑邮件列表属性"
 
-#: ./browser/sendnewsletter.py:277
+#: ../browser/sendnewsletter.py:325
 msgid "Enter a custom subject line for your newsletter here. Leave blank to use the default subject for the chosen content and mailing-list."
 msgstr "为快报输入一个主题行"
 
-#: ./browser/query.py:12
+#: ../browser/query.py:12
 msgid "Enter a search query to find content."
 msgstr "输入搜索查询以找到内容。"
 
-#: ./browser/channel.py:423
+#: ../browser/channel.py:467
 msgid "Error importing subscriber file. %s"
 msgstr "导入预定者文件错误。%s"
 
-#: ./browser/stats.py:43
+#: ../browser/stats.py:43
 msgid "Failed messages"
 msgstr "失败的邮件"
 
-#: ./browser/channel.py:555
+#: ../browser/channel.py:628
 msgid "File has incorrect format."
 msgstr "文件格式不正确"
 
-#: ./browser/channel.py:549
+#: ../browser/channel.py:621
 msgid "File was not given."
 msgstr "文件没有给定"
 
-#: ./browser/subscribe.py:45
+#: ../browser/subscribe.py:49
 msgid "Fill out the form below to receive an email with a link from which you can edit your subscriptions."
 msgstr "填写下面表单信息，以便能接收一个带链接的邮件，点击该链接可以编辑你的预订。"
 
-#: ./browser/subscribe.py:75
+#: ../browser/subscribe.py:79
 msgid "Fill out the form below to subscribe to ${channel}. Note that this is for new subscriptions. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "如果是新预定者，为预定新闻频道，请填写下面表单。如果有预定，点击下面链接${link_start}编辑您的预定${link_end}。"
 
-#: ./browser/portlets/channelsubscribe.py:37
+#: ../contentrules.py:223
+msgid "Filter by collector ${channel}"
+msgstr ""
+
+#: ../browser/portlets/channelsubscribe.py:37
 msgid "Find the mailing-list you want to enable direct subscription to"
 msgstr "搜索你想允许直接预定的邮件列表"
 
-#: ./browser/jobs.pt:19
+#: ../browser/jobs.pt:19
 msgid "Finished jobs"
 msgstr "已完成的作业"
 
-#: ./browser/portlets/channelsubscribe.py:48
-#: ./interfaces.py:52
+#: ../browser/portlets/channelsubscribe.py:48
+#: ../interfaces.py:71
 msgid "Footer text"
 msgstr "页脚文本"
 
-#: ./interfaces.py:29
+#: ../interfaces.py:44
 msgid "From address"
 msgstr "发送者地址"
 
-#: ./interfaces.py:24
+#: ../interfaces.py:37
 msgid "From name"
 msgstr "发送者名称"
 
-#: ./browser/channel.py:336
+#: ../browser/channel.py:337
 msgid "Generate"
 msgstr "生成"
 
-#: ./composer.py:160
+#: ../composer.py:162
 msgid "HTML E-Mail"
 msgstr "HTML格式邮件"
 
-#: ./interfaces.py:45
+#: ../interfaces.py:64
 msgid "Header text"
 msgstr "头部文本"
 
-#: ./browser/interfaces.py:15
+#: ../contentrules.py:73
+msgid "If not, only link, title  and summary will be sent"
+msgstr ""
+
+#: ../browser/interfaces.py:27
+#: ../contentrules.py:69
 msgid "Include collector items"
 msgstr "包括的收集器项目"
 
-#: ./browser/subscribe.py:333
+#: ../browser/subscribe.py:343
 msgid "Information on how to confirm your subscription has been sent to you."
 msgstr "您的预订确认邮件已发送到您的邮箱。"
 
-#: ./browser/collector.py:193
+#: ../browser/collector.py:193
 msgid "Item added successfully."
 msgstr "项目已成功添加。"
 
-#: ./browser/collector.py:204
+#: ../browser/collector.py:204
 msgid "Item successfully deleted."
 msgstr "项目成功删除"
 
-#: ./browser/collector.py:237
+#: ../browser/collector.py:237
 msgid "Item successfully moved."
 msgstr "项目成功移动"
 
-#: ./browser/query.py:11
+#: ../browser/query.py:11
 msgid "Items"
 msgstr "项目"
 
-#: ./browser/jobs.pt:23
+#: ../browser/jobs.pt:23
 msgid "Job title"
 msgstr "作业标题"
 
-#: ./browser/stats.py:34
+#: ../browser/stats.py:34
 msgid "Last Change"
 msgstr "上次更改"
 
-#: ./collector.py:58
+#: ../collector.py:58
 msgid "Latest news"
 msgstr ""
 
-#: ./browser/channel.py:223
+#: ../browser/channel.py:224
 msgid "Manage or add subscriptions."
 msgstr "管理或添加预订"
 
-#: ./browser/composer-html-forgot.pt:24
+#: ../browser/composer-html-forgot.pt:24
 msgid "Manage your subscriptions"
 msgstr "管理您的预订"
 
-#: ./interfaces.py:34
+#: ../interfaces.py:51
 msgid "Message subject"
 msgstr "邮件主题"
 
-#: ./browser/sendnewsletter.py:116
+#: ../browser/sendnewsletter.py:146
 msgid "Messages queued for delivery."
 msgstr "等候发送的消息队列"
 
-#: ./browser/stats.py:38
+#: ../browser/stats.py:38
 msgid "Messages successfully sent"
 msgstr "已成功发送的邮件"
 
-#: ./browser/stats.py:32
+#: ../browser/stats.py:32
 msgid "Messages waiting to be sent"
 msgstr "等候发送的邮件"
 
-#: ./browser/stats.py:44
+#: ../browser/stats.py:44
 msgid "Messages with errors"
 msgstr "有错误的邮件"
 
-#: ./browser/stats.py:50
+#: ../browser/stats.py:50
 msgid "Messages with errors in the retry queue"
 msgstr "重试队列中出错的邮件"
 
-#: ./browser/collector.py:240
+#: ../browser/collector.py:240
 msgid "Move block down"
 msgstr "下移"
 
-#: ./browser/collector.py:233
+#: ../browser/collector.py:233
 msgid "Move block up"
 msgstr "上移"
 
-#: ./collector.py:112
+#: ../collector.py:112
 msgid "Must be a weak reference (got ${title})"
 msgstr ""
 
-#: ./browser/subscribe.py:759
+#: ../browser/subscribe.py:772
 msgid "My subscriptions"
 msgstr "我的预订"
 
-#: ./browser/stats.py:31
+#: ../browser/stats.py:31
 msgid "New messages"
 msgstr "新邮件"
 
-#: ./channel.py:122
+#: ../channel.py:125
 msgid "Newsletter"
 msgstr "快报"
 
-#: ./channel.py:85
+#: ../channel.py:88
 msgid "Newsletters"
 msgstr "频道快报"
 
-#: ./browser/preview.py:78
+#: ../browser/preview.py:81
 msgid "No items found."
 msgstr "没有找到相应的项目。"
 
-#: ./browser/scheduler.py:39
+#: ../browser/scheduler.py:39
 msgid "No messages queued."
 msgstr "队列中没有邮件。"
 
-#: ./browser/channel.py:478
+#: ../browser/channel.py:550
 msgid "Only purge subscribers present in this list."
 msgstr "仅仅清空这个列表中的预定者。"
 
-#: ./browser/channel.py:671
+#: ../browser/channel.py:793
 msgid "Only some of your changes were saved"
 msgstr "仅仅某些改变成功保存"
 
-#: ./browser/jobs.pt:9
+#: ../interfaces.py:13
+msgid "Path to python script or zope object capable of return the current subscriptions"
+msgstr ""
+
+#: ../browser/jobs.pt:9
 msgid "Pending jobs"
 msgstr "待处理作业"
 
-#: ./browser/composer-html-confirm.pt:14
+#: ../browser/interfaces.py:17
+msgid "Pick a channel to send to the whole list. Pick a 'channel - section' to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../contentrules.py:60
+msgid "Pick a channel to send to the whole list. Pick a \"channel - section\" to send this is a segment of the mailing-list based on the optional section they subscribered to. Must have a Timed scheduler to work"
+msgstr ""
+
+#: ../browser/composer-html-confirm.pt:14
 msgid "Please confirm your subscription"
 msgstr "请确认你的预订"
 
-#: ./browser/sendnewsletter.py:133
+#: ../browser/sendnewsletter.py:169
 msgid "Please fill in a date."
 msgstr "请填充一个日期。"
 
-#: ./browser/stats.py:91
+#: ../browser/stats.py:91
 msgid "Please select items to remove."
 msgstr "请选择要删除的项目"
 
-#: ./browser/stats.py:100
+#: ../browser/stats.py:100
 msgid "Please select items with new messages to clear."
 msgstr "请选择带有新消息的项目清除。"
 
-#: ./browser/stats.py:109
+#: ../browser/stats.py:109
 msgid "Please select which mailing-list's queued e-mails you'd like to send."
 msgstr "请选择你想发送那个邮件列表的排队邮件。"
 
-#: ./browser/portlets/channelsubscribe.py:41
+#: ../browser/portlets/channelsubscribe.py:41
 msgid "Portlet description"
 msgstr "面板描述"
 
-#: ./browser/portlets/channelsubscribe.py:33
+#: ../browser/portlets/channelsubscribe.py:33
 msgid "Portlet header"
 msgstr "面板头部"
 
-#: ./browser/channel.py:756
-#: ./browser/sendnewsletter.py:166
+#: ../browser/channel.py:878
+#: ../browser/sendnewsletter.py:214
 msgid "Preview"
 msgstr "预览"
 
-#: ./browser/portlets/channelsubscribe.py:210
+#: ../browser/portlets/channelsubscribe.py:210
 msgid "Proceed"
 msgstr "处理"
 
-#: ./browser/stats.py:121
+#: ../browser/stats.py:121
 msgid "Process jobs"
 msgstr "处理作业"
 
-#: ./browser/channel.py:483
+#: ../browser/channel.py:555
 msgid "Purge list before import."
 msgstr "在导入前清空列表"
 
-#: ./browser/channel.py:482
+#: ../browser/channel.py:554
 msgid "Purge list."
 msgstr "清除列表"
 
-#: ./browser/collector.py:201
+#: ../browser/collector.py:201
 msgid "Remove block"
 msgstr "删除块"
 
-#: ./browser/scheduler.py:81
+#: ../browser/scheduler.py:81
 msgid "Remove entries"
 msgstr "删除条目"
 
-#: ./browser/stats.py:89
+#: ../browser/stats.py:89
 msgid "Remove old messages"
 msgstr "删除旧消息"
 
-#: ./browser/channel.py:477
+#: ../browser/channel.py:549
 msgid "Remove subscribers in list."
 msgstr "删除列表中的预定者"
 
-#: ./interfaces.py:40
+#: ../interfaces.py:57
 msgid "Reply-to address"
 msgstr "答复到的地址"
 
-#: ./browser/stats.py:49
+#: ../browser/stats.py:49
 msgid "Retry messages"
 msgstr "重试邮件"
 
-#: ./collector.py:75
+#: ../collector.py:75
 msgid "Rich text"
 msgstr "富文本"
 
-#: ./browser/collector.py:128
+#: ../browser/collector.py:128
 msgid "Rich text: ${title}"
 msgstr ""
 
-#: ./browser/channel.py:687
+#: ../browser/channel.py:809
 msgid "Save"
 msgstr "保存"
 
-#: ./browser/sendnewsletter.py:118
+#: ../browser/sendnewsletter.py:148
 msgid "Schedule distribution"
 msgstr "调度发布"
 
-#: ./browser/interfaces.py:29
+#: ../browser/interfaces.py:41
 msgid "Scheduled time"
 msgstr "调度时间"
 
-#: ./browser/channel.py:194
+#: ../interfaces.py:12
+msgid "Script path in this plone portal"
+msgstr ""
+
+#: ../browser/channel.py:195
 msgid "Search"
 msgstr "搜寻"
 
-#: ./browser/channel.py:191
+#: ../browser/channel.py:192
 msgid "Search subscribers"
 msgstr "搜索预订者"
 
-#: ./collector.py:218
+#: ../collector.py:218
 msgid "Sections"
 msgstr "段落"
 
-#: ./browser/channel.py:326
+#: ../browser/channel.py:327
 msgid "See an in-browser preview of the newsletter."
 msgstr "查看新闻快报在浏览器中预览。"
 
-#: ./browser/channel.py:488
+#: ../contentrules.py:198
+msgid "Select collector to filter item by. Optionally also select the specific section"
+msgstr ""
+
+#: ../browser/channel.py:560
 msgid "Select this if you want to use the csv header row to designate document variables.The header row must contain one 'email' field."
 msgstr "如果你要采用CSV表头行，选择这个，该表头行必须包含一个email字段。"
 
-#: ./browser/sendnewsletter.py:82
+#: ../browser/sendnewsletter.py:109
 msgid "Send"
 msgstr "发送"
 
-#: ./browser/sendnewsletter.py:268
+#: ../browser/sendnewsletter.py:316
 msgid "Send ${item} as newsletter"
 msgstr "发送${item}作为新闻快报"
 
-#: ./browser/sendnewsletter.py:109
+#: ../browser/sendnewsletter.py:139
 msgid "Send '${context}' through ${channel}."
 msgstr "通过 ${channel}发送'${context}'"
 
-#: ./profiles/default/actions.xml
+#: ../contentrules.py:72
+msgid "Send as Newsletter"
+msgstr ""
+
+#: ../profiles/default/actions.xml
 msgid "Send as newsletter"
 msgstr "作为新闻快报发送"
 
-#: ./browser/sendnewsletter.py:192
+#: ../browser/sendnewsletter.py:240
 msgid "Send preview"
 msgstr "发件预览"
 
-#: ./browser/stats.py:107
+#: ../browser/stats.py:107
 msgid "Send queued messages now"
 msgstr "马上发送队列中信息。"
 
-#: ./browser/stats.py:37
+#: ../contentrules.py:100
+msgid "Send to channel: ${channel}"
+msgstr ""
+
+#: ../browser/stats.py:37
 msgid "Sent messages"
 msgstr "已发送的邮件"
 
-#: ./browser/prettysubscriptions.pt:24
-#: ./browser/subscriptions.pt:34
+#: ../browser/prettysubscriptions.pt:24
+#: ../browser/subscriptions.pt:34
 msgid "Should you be already subscribed to one of our lists, please use this form to retrieve a link to your personalized subscription page:"
 msgstr "你应该已经预订了我们的快报，请填写下面表单，以获取一个指向你个人预订配置页的链接。"
 
-#: ./browser/portlets/channelsubscribe.py:52
+#: ../browser/portlets/channelsubscribe.py:52
 msgid "Show footer"
 msgstr "显示页脚"
 
-#: ./browser/sendnewsletter.py:173
+#: ../browser/sendnewsletter.py:221
 msgid "Show preview"
 msgstr "显示预览"
 
-#: ./browser/controlpanel.py:22
+#: ../browser/controlpanel.py:22
 msgid "Singing & Dancing configuration"
 msgstr "S&D配置"
 
-#: ./channel.py:136
+#: ../channel.py:139
 msgid "Standard Channel"
 msgstr "标准频道"
 
-#: ./browser/jobs.pt:24
+#: ../browser/jobs.pt:24
 msgid "Status"
 msgstr "状态"
 
-#: ./browser/subscribe.py:271
+#: ../browser/subscribe.py:278
 msgid "Subscribe"
 msgstr "预定"
 
-#: ./browser/portlets/channelsubscribe.py:44
+#: ../browser/portlets/channelsubscribe.py:44
 msgid "Subscribe directly from portlet"
 msgstr "直接从面板预订"
 
-#: ./browser/subscribe.py:85
+#: ../browser/subscribe.py:89
 msgid "Subscribe to ${channel}"
 msgstr "预订${channel}频道"
 
-#: ./browser/channel.py:468
+#: ../browser/channel.py:540
 msgid "Subscribers"
 msgstr "预订者"
 
-#: ./browser/channel.py:646
+#: ../browser/channel.py:768
 msgid "Subscribers exported."
 msgstr "已导出的预订者"
 
-#: ./browser/channel.py:751
+#: ../browser/channel.py:873
 msgid "Subscriptions"
 msgstr "预订者"
 
-#: ./browser/stats.py:103
+#: ../channel.py:209
+msgid "Subscriptions from Script Channel"
+msgstr ""
+
+#: ../browser/stats.py:103
 msgid "Successfully cleared queued messages in mailing-lists."
 msgstr "已从邮件列表中删除排队的信息。"
 
-#: ./browser/stats.py:94
+#: ../browser/stats.py:94
 msgid "Successfully removed old messages from mailing-lists."
 msgstr "已从邮件列表中删除旧信息。"
 
-#: ./browser/sendnewsletter.py:142
+#: ../browser/sendnewsletter.py:178
 msgid "Successfully scheduled distribution."
 msgstr "已成功调度分发"
 
-#: ./interfaces.py:62
+#: ../interfaces.py:81
 msgid "Template"
 msgstr "模版"
 
-#: ./browser/portlets/channelsubscribe.py:49
+#: ../browser/portlets/channelsubscribe.py:49
 msgid "Text in footer - if omitted the mailing-list title is used"
 msgstr "邮件页脚区文本，默认采用邮件列表标题"
 
-#: ./interfaces.py:46
+#: ../interfaces.py:65
 msgid "Text to appear at the beginning of every message. You may use a number of variables here including ${subject}."
 msgstr "附加在每份邮件开头部的文本。该处可以用各种变量包括${subject}。"
 
-#: ./interfaces.py:53
+#: ../interfaces.py:72
 msgid "Text to appear at the end of every message"
 msgstr "附加在每一个邮件尾部的文本"
 
-#: ./browser/sendnewsletter.py:202
+#: ../browser/subscribe.pt:23
+msgid "The Mailing-list '${channel}' is not open for subscriptions."
+msgstr ""
+
+#: ../browser/sendnewsletter.py:250
 msgid "The address to send the preview to is missing."
 msgstr "发送预览的邮件地址缺失。"
 
-#: ./browser/channel.py:495
+#: ../browser/channel.py:567
 msgid "The delimiter in your CSV file. (Usually ',' or ';', but no quotes are necessary.)"
 msgstr "在你的CSV文件的分割符，（通常是',' 或 ';'）"
 
-#: ./interfaces.py:30
+#: ../interfaces.py:45
 msgid "The from address that will appear in messages sent from this composer."
 msgstr "发送者地址将出现在邮件中。"
 
-#: ./browser/portlets/channelsubscribe.py:36
+#: ../browser/portlets/channelsubscribe.py:36
 msgid "The mailing-list to enable subscriptions to."
 msgstr "这个邮件列表允许预定到"
 
-#: ./browser/interfaces.py:10
+#: ../browser/interfaces.py:11
 msgid "The mailing-list to send this through"
 msgstr "通过这个邮件列表发送吗？"
 
-#: ./interfaces.py:41
+#: ../browser/interfaces.py:16
+#: ../contentrules.py:59
+msgid "The mailing-list/section to send this to"
+msgstr ""
+
+#: ../interfaces.py:58
 msgid "The reply-to address that will appear in messages sent from this composer."
 msgstr "回复到地址将出现在邮件中。"
 
-#: ./interfaces.py:25
+#: ../interfaces.py:38
 msgid "The sender name that will appear in messages sent from this mailing-list."
 msgstr "发送者的名称将出现在邮件的发送者栏中。"
 
-#: ./interfaces.py:58
+#: ../interfaces.py:77
 msgid "The stylesheet will be applied to the document."
 msgstr "这个样式表将应用到文档。"
 
-#: ./interfaces.py:63
+#: ../interfaces.py:82
 msgid "The template that will be used."
 msgstr "这个模板将被采用。"
 
-#: ./browser/subscribe.py:347
+#: ../browser/subscribe.py:357
 msgid "There seems to be an error with the information you entered."
 msgstr "看起来你输入的信息有错。"
 
-#: ./browser/portlets/channelsubscribe.py:201
+#: ../browser/portlets/channelsubscribe.py:201
 msgid "There were some errors."
 msgstr "有一些错误."
 
-#: ./browser/interfaces.py:30
+#: ../browser/interfaces.py:42
 msgid "This is only required if you click 'Schedule distribution' below"
 msgstr "如果你采用下面的'调度分发'，这里才要求要。"
 
-#: ./browser/interfaces.py:23
+#: ../browser/interfaces.py:35
 msgid "This is only required if you click 'Send preview' below"
 msgstr "这个只有在点击'发送预览时'，才要求"
 
-#: ./browser/portlets/channelsubscribe.py:411
+#: ../browser/portlets/channelsubscribe.py:411
 msgid "This portlet allows a visitor to subscribe to a specific newsletter."
 msgstr "这个面板允许用户预订新闻快报频道。"
 
-#: ./browser/collector.py:93
-#: ./browser/stats.py:23
+#: ../browser/collector.py:93
+#: ../browser/stats.py:23
 msgid "Title"
 msgstr "标题"
 
-#: ./browser/portlets/channelsubscribe.py:34
+#: ../browser/portlets/channelsubscribe.py:34
 msgid "Title of the rendered portlet"
 msgstr "呈现面板的标题"
 
-#: ./browser/composer-html-confirm.pt:20
+#: ../browser/composer-html-confirm.pt:20
 msgid "To confirm your subscription with ${channel}, please click here: ${url}"
 msgstr "为了确认在http://ddsep.cea-igp.ac.cn预订的快报频道，请点击这个链接：${url}<p>若您没有在网站<strong>重要地震震源信息</strong>上提交订阅，请忽略此邮件。</p>"
 
-#: ./browser/stats.py:26
+#: ../browser/stats.py:26
 msgid "Total messages sent"
 msgstr "已发送邮件数量"
 
-#: ./browser/stats.py:27
+#: ../browser/stats.py:27
 msgid "Total number of messages sent successsfully"
 msgstr "总共成功发送的邮件数量"
 
-#: ./browser/scheduler.py:31
+#: ../browser/scheduler.py:31
 msgid "Trigger now"
 msgstr "马上触发"
 
-#: ./browser/channel.py:111
-#: ./browser/collector.py:40
+#: ../browser/channel.py:112
+#: ../browser/collector.py:40
 msgid "Type"
 msgstr "类型"
 
-#: ./browser/channel.py:587
+#: ../browser/channel.py:709
 msgid "Unknown"
 msgstr "未知"
 
-#: ./browser/subscribe.py:132
+#: ../browser/subscribe.py:137
 msgid "Unsubscribe"
 msgstr "退订"
 
-#: ./browser/subscribe.py:221
+#: ../browser/subscribe.py:227
 msgid "Unsubscribe from newsletter"
 msgstr "解除快报预订"
 
-#: ./browser/collector.py:337
+#: ../browser/collector.py:337
 msgid "Up to Collector administration"
 msgstr "去到收集器（内容）管理"
 
-#: ./browser/channel.py:725
-#: ./browser/scheduler.py:99
+#: ../browser/channel.py:847
+#: ../browser/scheduler.py:99
 msgid "Up to Mailing-lists administration"
 msgstr "去到邮件列表管理"
 
-#: ./browser/controlpanel.py:15
+#: ../browser/controlpanel.py:15
 msgid "Up to Singing & Dancing configuration"
 msgstr "去到S&D设置"
 
-#: ./browser/controlpanel.py:25
+#: ../browser/controlpanel.py:27
 msgid "Up to Site Setup"
 msgstr "去到站点设置"
 
-#: ./browser/channel.py:462
+#: ../browser/channel.py:534
 msgid "Upload"
 msgstr "上载"
 
-#: ./browser/channel.py:469
+#: ../browser/channel.py:541
 msgid "Upload a CSV file with a list of subscribers here. Subscribers already present in the database will be overwritten. Each line should contain: ${columns}."
 msgstr "上载一个包含预订者列表的CSV文件，每行应该包含：${columns}。系统中原有的预订者列表将被覆盖。"
 
-#: ./browser/channel.py:651
+#: ../browser/channel.py:773
 msgid "Upload list of subscribers."
 msgstr "上载预订者列表"
 
-#: ./channel.py:71
+#: ../channel.py:74
 msgid "Use single form subscriptions page"
 msgstr "采用单表单预定页"
 
-#: ./channel.py:72
+#: ../channel.py:75
 msgid "Use single form subscriptions page when possible."
 msgstr "如果可能，采用单表单预定页"
 
-#: ./browser/portlets/channelsubscribe.py:147
+#: ../browser/portlets/channelsubscribe.py:147
 msgid "You are already subscribed to this newsletter. Click here to ${link_start}edit your subscriptions${link_end}."
 msgstr "你已预定了该频道，点击这儿${link_start}编辑预定${link_end}"
 
-#: ./browser/subscribe.py:343
+#: ../browser/subscribe.py:353
 msgid "You are already subscribed. Fill out the form at the end of this page to be sent a link from where you can edit your subscription."
 msgstr "你已经预订了。填写下面表单，以便发送一个链接，点击该链接即可编辑你的预订。"
 
-#: ./browser/subscriptions.pt:21
+#: ../browser/subscriptions.pt:21
 msgid "You are currently subscribed to these newsletters:"
 msgstr "你当前已预订了这些频道："
 
-#: ./browser/subscribe.py:145
+#: ../browser/subscribe.py:151
 msgid "You aren't subscribed to this mailing-list."
 msgstr "你不能预定这个邮件列表。"
 
-#: ./browser/channel.py:633
+#: ../browser/channel.py:755
 msgid "You can not add things in purge only mode!"
 msgstr "在清理模式不能添加任何东西！"
 
-#: ./browser/subscriptions.pt:28
+#: ../browser/subscriptions.pt:28
 msgid "You can subscribe to these newsletters:"
 msgstr "你能预订这些快报："
 
-#: ./browser/subscribe.py:104
+#: ../browser/subscribe.py:108
 msgid "You confirmed your subscription successfully."
 msgstr "你确认预订成功"
 
-#: ./interfaces.py:35
+#: ../interfaces.py:52
 msgid "You may use a number of variables here, like ${site_title}."
 msgstr "这儿可以用一些变量，如 ${site-title}。"
 
-#: ./browser/subscribe.py:327
+#: ../browser/subscribe.py:337
 msgid "You subscribed successfully."
 msgstr "你预订成功"
 
-#: ./browser/subscribe.py:143
+#: ../browser/subscribe.py:149
 msgid "You unsubscribed successfully."
 msgstr "你解除预订成功"
 
-#: ./browser/subscribe.py:723
+#: ../browser/subscribe.py:736
 msgid "You were unsubscribed completely."
 msgstr ""
 
-#: ./browser/composer-html.pt:39
+#: ../browser/composer-html.pt:39
 msgid "You're receiving this e-mail because you're registered for the ${channel} newsletter."
 msgstr "你接收了这个邮件是因为你在我们网站预定了${channel} 频道快报。"
 
-#: ./composer.py:50
+#: ../composer.py:52
 msgid "Your e-mail address is invalid"
 msgstr "你的邮件地址无效"
 
-#: ./browser/subscribe.py:34
+#: ../browser/subscribe.py:38
 msgid "Your email address is already subscribed. Click the 'Send my subscription details' button below."
 msgstr "你的邮件地址已预定，点击下面按钮'发送预定详情'"
 
-#: ./browser/subscribe.py:105
+#: ../browser/subscribe.py:109
 msgid "Your subscription isn't known to us."
 msgstr "你的预订不可识别。"
 
-#: ./browser/subscribe.py:175
+#: ../browser/subscribe.py:181
 msgid "Your subscription was updated."
 msgstr "您的预定已更新。"
 
 #. Default: "A Mailing-list is a hub of configuration. It doesn't do anything by itself. Rather, it provides a number of components to configure and work with. It is also the container of subscriptions to it."
-#: ./browser/controlpanel-links.pt:7
+#: ../browser/controlpanel-links.pt:7
 msgid "description_channel_administration"
 msgstr "频道管理"
 
 #. Default: "Collectors are useful for automatic newsletters. They are responsible for assembling a list of items for publishing."
-#: ./browser/controlpanel-links.pt:18
+#: ../browser/controlpanel-links.pt:18
 msgid "description_collector_administration"
 msgstr "收集器管理"
 
 #. Default: "Change some aspects of how Singing & Dancing behaves."
-#: ./browser/controlpanel-links.pt:28
+#: ../browser/controlpanel-links.pt:28
 msgid "description_globalsettings_administration"
 msgstr "更改邮件预定行为配置"
 
 #. Default: "View newsletter statistics"
-#: ./browser/controlpanel-links.pt:37
+#: ../browser/controlpanel-links.pt:37
 msgid "description_statistics_administration"
 msgstr "查看快报统计"
 
 #. Default: "Mailing-list administration"
-#: ./browser/channel.py:176
-#: ./browser/controlpanel-links.pt:3
+#: ../browser/channel.py:177
+#: ../browser/controlpanel-links.pt:3
 msgid "label_channel_administration"
 msgstr "频道管理"
 
 #. Default: "Collector administration"
-#: ./browser/collector.py:66
-#: ./browser/controlpanel-links.pt:13
+#: ../browser/collector.py:66
+#: ../browser/controlpanel-links.pt:13
 msgid "label_collector_administration"
 msgstr "收集器管理"
 
 #. Default: "Global settings"
-#: ./browser/controlpanel-links.pt:23
-#: ./browser/settings.py:15
+#: ../browser/controlpanel-links.pt:23
+#: ../browser/settings.py:15
 msgid "label_newsletters_settings_administration"
 msgstr "全局配置"
 
 #. Default: "(Required)"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "label_required"
 msgstr "要求填写"
 
 #. Default: "Statistics"
-#: ./browser/controlpanel-links.pt:32
-#: ./browser/stats.py:178
+#: ../browser/controlpanel-links.pt:32
+#: ../browser/stats.py:178
 msgid "label_statistics_administration"
 msgstr "统计"
 
 #. Default: "Required"
-#: ./browser/portlets/htmlstatusform.pt:39
+#: ../browser/portlets/htmlstatusform.pt:39
 msgid "title_required"
 msgstr "要求填写"
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
+- Do not show subscription form on channel/subscribe.html if
+  `channel.subscribeable == False` [fRiSi]
+
+
 1.0.2 (2015-11-03)
 ------------------
 


### PR DESCRIPTION
 do not allow to subscribe to channels closed for subscriptions

Currently channel.subscribeable only affects if the channel is listed in subscription forms, but the naming suggest, that setting this to False would not allow users to subscribe to this channel at all.

This PR shows a message that the user can't subscribe to the channel if `channel.subscribeable==False`. The subscription form will be hidden in this case.