### PR TITLE
export subscription metadata

### DIFF
--- a/collective/dancing/browser.txt
+++ b/collective/dancing/browser.txt
@@ -647,18 +647,17 @@ Subscriptions can be downloaded as csv:
   >>> browser.getControl('Download').click()
   >>> browser.headers['content-type']
   'text/csv; charset=UTF-8'
-  >>> 'email,section,section\r\n' in browser.contents
+  >>> 'email,section,section,creation_date,pending,format,language,cue,secret\r\n' in browser.contents
   True
-  >>> 'daniel@domain.tld,,\r\n' in browser.contents
-  True
-  >>> 'mailman@domain.tld,,News (0)\r\n' in browser.contents
-  True
-  >>> 'lars@domain.tld,,\r\n' in browser.contents
-  True
-  >>> 'pia@domain.tld,,\r\n' in browser.contents
-  True
-  >>> 'pengo@domain.tld,,\r\n' in browser.contents
-  True
+  >>> import csv
+  >>> import StringIO
+  >>> reader = csv.reader(StringIO.StringIO(browser.contents))
+  >>> rows = [row for row in reader]
+  >>> rows
+  [...['daniel@domain.tld', '', '', '...', 'imported', 'html', '', 'never-received-newsletter', '...']...]
+  >>> [values[0] for values in rows]
+  ['email', 'mailman@domain.tld', 'daniel@domain.tld', 'lars@domain.tld', 'pengo@domain.tld', 'pia@domain.tld']
+
 
 Now add custom composer with different types of fields inside it's schema and
 check if we can still download subscribers as csv file.
@@ -693,18 +692,24 @@ Download csv file:
   >>> browser.getControl(name='crud-add.my_format.buttons.download').click()
   >>> browser.headers['content-type']
   'text/csv; charset=UTF-8'
-  >>> 'email,section,section\r\n' in browser.contents
-  True
-  >>> 'daniel@domain.tld,,\r\n' in browser.contents
-  True
-  >>> 'mailman@domain.tld,,News (0)\r\n' in browser.contents
-  True
-  >>> 'lars@domain.tld,,\r\n' in browser.contents
-  True
-  >>> 'pia@domain.tld,,\r\n' in browser.contents
-  True
-  >>> 'pengo@domain.tld,,\r\n' in browser.contents
-  True
+
+It contains data for all composers
+
+  >>> reader = csv.reader(StringIO.StringIO(browser.contents))
+  >>> rows = [row for row in reader]
+
+  >>> rows[0]
+  ['name', 'email', 'programmer', 'interests', 'registered', 'section', 'section', 'creation_date', 'pending', 'format', 'language', 'cue', 'secret']
+  >>> rows[1]
+  ['Elvis Presley', 'elvis@mail.com', 'True', '', '21/11/2010 00:00:00', '', '', '...', 'imported', 'my_format', '', 'never-received-newsletter', '...']
+
+  >>> rows[2]
+  ['email', 'section', 'section', 'creation_date', 'pending', 'format', 'language', 'cue', 'secret']
+  >>> [values[0] for values in rows[2:]]
+  ['email', 'mailman@domain.tld', 'daniel@domain.tld', 'lars@domain.tld', 'pengo@domain.tld', 'pia@domain.tld']
+  >>> [values[2] for values in rows[2:]]
+  ['section', 'News (0)', '', '', '', '']
+
 
 Cleanup:
 

--- a/collective/dancing/browser/channel.py
+++ b/collective/dancing/browser/channel.py
@@ -494,7 +494,8 @@ class ExportCSV(BrowserView):
                         .get_optional_collectors():
                     title_id = optional.title.strip() + ' (' + optional.id + ')'
                     collectors_keys.append(title_id)
-        subscription_data = ['creation_date', 'pending', 'cue', 'secret']
+        subscription_data = [
+            'creation_date', 'pending', 'format', 'language', 'cue', 'secret']
         for format in self.context.composers.keys():
             composers_keys = field.Fields(
                 self.context.composers[format].schema).keys()
@@ -522,7 +523,10 @@ class ExportCSV(BrowserView):
                 # add subsciption_data
                 row.append(subscription.metadata.get('date', ''))
                 row.append(subscription.metadata.get('pending', 'imported'))
-                row.append(subscription.metadata.get('cue', 'never-received-newsletter'))
+                row.append(subscription.metadata.get('format', ''))
+                row.append(subscription.metadata.get('language', ''))
+                row.append(subscription.metadata.get(
+                    'cue', 'never-received-newsletter'))
                 row.append(HTMLComposer.secret(subscription.composer_data))
 
                 writer.writerow(row)

--- a/collective/dancing/browser/channel.py
+++ b/collective/dancing/browser/channel.py
@@ -1,46 +1,48 @@
-import types
-import cStringIO
-import datetime
-import sys
-import sets
-import csv
-from zope import interface
+from Acquisition import aq_inner
+from Globals import DevelopmentMode
+from Products.CMFCore.interfaces import IPropertiesTool
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from collective.dancing import MessageFactory as _
+from collective.dancing import channel
+from collective.dancing import utils
+from collective.dancing.browser import controlpanel
+from collective.dancing.browser.interfaces import ISendAndPreviewForm
+from collective.dancing.composer import check_email
+from collective.dancing.interfaces import ISubscriptionsFromScriptChannel
+from collective.dancing.utils import switch_on
+from collective.singing.interfaces import IChannel, ICollectorSchema
+from plone.app.z3cform import wysiwyg
+from plone.z3cform.crud import crud
+from z3c.form import field, form
 from zope import component
+from zope import interface
 from zope import schema
+import OFS.SimpleItem
+import Products.CMFPlone.utils
+import cStringIO
+import collective.singing.channel
+import collective.singing.scheduler
+import collective.singing.subscribe
+
+import csv
+import datetime
+import sets
+import sys
+import types
+import z3c.form.button
+import z3c.form.datamanager
+import z3c.form.interfaces
+import z3c.form.term
+import zope.i18n
 import zope.interface
 import zope.schema.interfaces
 import zope.schema.vocabulary
-import zope.i18n
-from z3c.form import field, form
-import z3c.form.interfaces
-import z3c.form.datamanager
-import z3c.form.term
-import z3c.form.button
-import OFS.SimpleItem
-from Globals import DevelopmentMode
-from Products.Five import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.CMFCore.interfaces import IPropertiesTool
-from Acquisition import aq_inner
-import Products.CMFPlone.utils
-from collective.singing.interfaces import IChannel, ICollectorSchema
-from plone.z3cform.crud import crud
-from plone.app.z3cform import wysiwyg
-import collective.singing.scheduler
-import collective.singing.subscribe
-import collective.singing.channel
+
 try:
     from zope.app.pagetemplate import viewpagetemplatefile
 except ImportError:
     from zope.browserpage import viewpagetemplatefile
-from collective.dancing import MessageFactory as _
-from collective.dancing import utils
-from collective.dancing import channel
-from collective.dancing.composer import check_email
-from collective.dancing.browser import controlpanel
-from collective.dancing.browser.interfaces import ISendAndPreviewForm
-from collective.dancing.utils import switch_on
-from collective.dancing.interfaces import ISubscriptionsFromScriptChannel
 
 
 def simpleitem_wrap(klass, name):
@@ -344,7 +346,7 @@ class ChannelPreviewForm(z3c.form.form.Form):
         collector_items = int(bool(data['include_collector_items']))
 
         return self.request.response.redirect(
-            self.context.absolute_url()+\
+            self.context.absolute_url() + \
             '/preview-newsletter.html?include_collector_items=%d' % \
             collector_items)
 
@@ -536,7 +538,7 @@ class UploadForm(crud.AddForm):
     @property
     def fields(self):
         subscriberdata = schema.Bytes(
-            __name__ = 'subscriberdata',
+            __name__='subscriberdata',
             title=_(u"Subscribers"),
             description=_(u"Upload a CSV file with a list of subscribers here. "
                           u"Subscribers already present in the database will "
@@ -545,28 +547,28 @@ class UploadForm(crud.AddForm):
                           mapping=dict(columns=';'.join(field.Fields(
                                          self.context.composer.schema).keys())))
         )
-        onlyremove = schema.Bool(__name__ = 'onlyremove',
+        onlyremove = schema.Bool(__name__='onlyremove',
             title=_(u"Remove subscribers in list."),
             description=_(u"Only purge subscribers present in this list."),
-            default = False
+            default=False
         )
-        remove = schema.Bool(__name__ = 'removenonexisting',
+        remove = schema.Bool(__name__='removenonexisting',
             title=_(u"Purge list."),
             description=_(u"Purge list before import."),
-            default = False
+            default=False
         )
-        header_row_present = schema.Bool(__name__ = 'header_row_present',
+        header_row_present = schema.Bool(__name__='header_row_present',
             title=_(u"CSV contains a header row"),
             description=_(u"Select this if you want to use the csv "
                           u"header row to designate document variables."
                           u"The header row must contain one 'email' field."),
-            default = False
+            default=False
         )
-        csv_delimiter = schema.TextLine(__name__ = 'csv_delimiter',
+        csv_delimiter = schema.TextLine(__name__='csv_delimiter',
             title=_(u"CSV delimiter"),
             description=_(u"The delimiter in your CSV file. "
                           u"(Usually ',' or ';', but no quotes are necessary.)"),
-            default = u','
+            default=u','
         )
 
         return field.Fields(subscriberdata, remove, onlyremove,
@@ -624,7 +626,7 @@ class UploadForm(crud.AddForm):
             self.context.composer,
             header_row_present=header_row_present,
             delimiter=delimiter)
-        if not type(subscribers)==type([]):
+        if not type(subscribers) == type([]):
             return _(u"File has incorrect format.")
 
         # generate new selected collectors

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -2,7 +2,39 @@ Changelog
 =========
 
 1.0.3 (unreleased)
-------------------
+------------------c
+
+- Include metadata when exporting subscriptions for a channel:
+
+  * creation_date: The creation date of this subscription
+
+  * pending:
+
+    allows to identify subscriptions that have not been validated (pending=True)
+    (otherwhise ex- and importing would add users that did not confirm their subscription)
+
+    True
+      subscription has not been validated (will not receive newsletters)
+
+    False
+      subscription has been validate
+
+    imported
+      subscription has been imported or added by an admin
+
+  * cue:
+
+    The date this subscription has received the last newsletter
+
+  * secret:
+
+    Used to authenticate when (un-)subscribing and editing personal preferences
+
+    * portal_newsletters/channels/my-channel/unsubscribe.html?secret=8a27d9c4fc2f8f0f031d654dc3172844
+
+    * portal_newsletters/my-subscriptions.html?secret=8a27d9c4fc2f8f0f031d654dc3172844
+
+    Future versions might support to import the secret so unsubscribe links work after re-importing a subscription.
 
 - Do not show subscription form on channel/subscribe.html if
   `channel.subscribeable == False` [fRiSi]

--- a/docs/THANKS.rst
+++ b/docs/THANKS.rst
@@ -10,6 +10,7 @@ Thanks to the following people for support, code, patches, etc:
   - David Pico
   - Giuseppe Zizza
   - Hanno Schlichting
+  - Harald Friessnegger
   - Jakob Bartholdy Bruun
   - Jens W. Klein
   - Katja Suess


### PR DESCRIPTION
this adds metadata to the csv export of channel subscribers.

this allows to identify subscriptions that have not been validated (pending=True) (otherwhise ex- and importing would add users that did not confirm their subscription)

see changelog for details

(see https://github.com/collective/collective.dancing/issues/15)