### PR TITLE
mark subscriptions as unsubscribed

### DIFF
--- a/collective/dancing/browser.txt
+++ b/collective/dancing/browser.txt
@@ -500,7 +500,7 @@ then 'add_subscription' with the modified subscription object:
   >>> subscription = subscriptions['daniele@domain.tld-html']
   >>> subscriptions.remove_subscription(subscription)
   >>> subscription.composer_data['email'] = 'daniel@domain.tld'
-  >>> subscriptions.add_subscription_obj(subscription)
+  >>> _ = subscriptions.add_subscription_obj(subscription)
 
 CSV Upload and Download of subscriptions
 ----------------------------------------
@@ -647,14 +647,14 @@ Subscriptions can be downloaded as csv:
   >>> browser.getControl('Download').click()
   >>> browser.headers['content-type']
   'text/csv; charset=UTF-8'
-  >>> 'email,section,section,creation_date,pending,format,language,cue,secret\r\n' in browser.contents
+  >>> 'email,section,section,creation_date,pending,unsubscribed,format,language,cue,secret\r\n' in browser.contents
   True
   >>> import csv
   >>> import StringIO
   >>> reader = csv.reader(StringIO.StringIO(browser.contents))
   >>> rows = [row for row in reader]
   >>> rows
-  [...['daniel@domain.tld', '', '', '...', 'imported', 'html', '', 'never-received-newsletter', '...']...]
+  [...['daniel@domain.tld', '', '', '...', 'imported', '', 'html', '', 'never-received-newsletter', '...']...]
   >>> [values[0] for values in rows]
   ['email', 'mailman@domain.tld', 'daniel@domain.tld', 'lars@domain.tld', 'pengo@domain.tld', 'pia@domain.tld']
 
@@ -699,12 +699,12 @@ It contains data for all composers
   >>> rows = [row for row in reader]
 
   >>> rows[0]
-  ['name', 'email', 'programmer', 'interests', 'registered', 'section', 'section', 'creation_date', 'pending', 'format', 'language', 'cue', 'secret']
+  ['name', 'email', 'programmer', 'interests', 'registered', 'section', 'section', 'creation_date', 'pending', 'unsubscribed', 'format', 'language', 'cue', 'secret']
   >>> rows[1]
-  ['Elvis Presley', 'elvis@mail.com', 'True', '', '21/11/2010 00:00:00', '', '', '...', 'imported', 'my_format', '', 'never-received-newsletter', '...']
+  ['Elvis Presley', 'elvis@mail.com', 'True', '', '21/11/2010 00:00:00', '', '', '...', 'imported', '', 'my_format', '', 'never-received-newsletter', '...']
 
   >>> rows[2]
-  ['email', 'section', 'section', 'creation_date', 'pending', 'format', 'language', 'cue', 'secret']
+  ['email', 'section', 'section', 'creation_date', 'pending', 'unsubscribed', 'format', 'language', 'cue', 'secret']
   >>> [values[0] for values in rows[2:]]
   ['email', 'mailman@domain.tld', 'daniel@domain.tld', 'lars@domain.tld', 'pengo@domain.tld', 'pia@domain.tld']
   >>> [values[2] for values in rows[2:]]
@@ -956,6 +956,20 @@ pending:
   >>> second_subscription.metadata['pending']
   False
 
+Confirming an unsubscribed subscription results in the same error as if a non
+existent secret was given
+
+  >>> subscription.metadata['unsubscribed'] = DateTime()
+  >>> second_subscription.metadata['unsubscribed'] = DateTime()
+  >>> browser.open(confirm_url + '?' + secret)
+  >>> "Your subscription isn't known to us" in browser.contents
+  True
+
+  # reset subscription state
+  >>> subscription.metadata['unsubscribed'] = None
+  >>> second_subscription.metadata['unsubscribed'] = None
+
+
 
 Cleanup our subscription to the default-channel:
 
@@ -1034,6 +1048,20 @@ We're now no longer subscribed:
   True
 
   >>> delivery.sent = []
+
+The subscription has not been deleted but marked as 'unsubscribed'.
+This helps admins that need to re-import subscribers from thirdparty datasources
+to sort out who unsubscribed in the meantime and should not be included in the re-import
+(see https://github.com/collective/collective.dancing/issues/15)
+
+  >>> subs = list(channel.subscriptions.query(key='daemon@domain.tld'))
+  >>> len(subs)
+  1
+  >>> subs[0].metadata['unsubscribed']
+  DateTime(...)
+  >>> subs[0].metadata['unsubscribed'].Date() == DateTime().Date()
+  True
+
 
 Of course, not providing a secret is an error:
 
@@ -1115,18 +1143,25 @@ when it queued something the last time:
   >>> now - channel.scheduler.delta < channel.scheduler.triggered_last
   True
 
-Secondly, all our subscriptions have a "cue" set, which marks the time
+Secondly, all our active subscriptions have a "cue" set, which marks the time
 when they last received an item:
 
   >>> subscriptions = channel.subscriptions.values()
-  >>> [s.metadata['cue'] for s in subscriptions] # doctest: +ELLIPSIS
-  [DateTime(...), DateTime(...), DateTime(...)]
+  >>> [s.metadata.get('cue','not-sent') for s in subscriptions] # doctest: +ELLIPSIS
+  ['not-sent', DateTime(...), DateTime(...), DateTime(...)]
+
+The first subscription has no cue date because it belongs to the subscription
+of daemon@domain.tld who unsubscribed before
+
+  >>> [s.metadata.get('unsubscribed',None) for s in subscriptions] # doctest: +ELLIPSIS
+  [DateTime(...), None, None, None]
 
 We have to reset *both* the cues and the ``triggered_last`` time for
 messages to be queued again:
 
   >>> for subs in subscriptions:
-  ...     del subs.metadata['cue']
+  ...     if 'cue' in subs.metadata.keys():
+  ...         del subs.metadata['cue']
   >>> channel.scheduler.tick(channel, request)
 
   >>> channel.scheduler.triggered_last = datetime.datetime(1, 1, 1, 0, 0)
@@ -1170,7 +1205,8 @@ still have their cues set:
 
   >>> channel.scheduler.tick(channel, request)
   >>> for subs in subscriptions:
-  ...     del subs.metadata['cue']
+  ...     if 'cue' in subs.metadata.keys():
+  ...         del subs.metadata['cue']
   >>> channel.scheduler.tick(channel, request)
 
 We can visit the scheduler's management screen to activate it:
@@ -1195,7 +1231,8 @@ The scheduler will send messages now:
 Now it's silent again:
 
   >>> for subs in subscriptions:
-  ...     del subs.metadata['cue']
+  ...     if 'cue' in subs.metadata.keys():
+  ...         del subs.metadata['cue']
   >>> channel.scheduler.tick(channel, request)
 
 We can manually trigger the scheduler and thereby override the time

--- a/collective/dancing/browser/channel.py
+++ b/collective/dancing/browser/channel.py
@@ -46,11 +46,12 @@ except ImportError:
     from zope.browserpage import viewpagetemplatefile
 
 
-
 def simpleitem_wrap(klass, name):
+
     class SimpleItemWrapper(klass, OFS.SimpleItem.SimpleItem):
         __doc__ = OFS.SimpleItem.SimpleItem.__doc__
         id = name
+
         def Title(self):
             return klass.title
 
@@ -61,19 +62,23 @@ def simpleitem_wrap(klass, name):
     setattr(module, klassname, SimpleItemWrapper)
     return SimpleItemWrapper
 
+
 schedulers = [
     simpleitem_wrap(klass, 'scheduler')
     for klass in collective.singing.scheduler.schedulers]
 
 csv_delimiter = ","
 
+
 class FactoryChoice(schema.Choice):
+
     def _validate(self, value):
         if self._init_field:
             return
         super(schema.Choice, self)._validate(value)
 
         # We'll skip validating against the vocabulary
+
 
 def scheduler_vocabulary(context):
     terms = []
@@ -84,10 +89,14 @@ def scheduler_vocabulary(context):
                 token='%s.%s' % (factory.__module__, factory.__name__),
                 title=factory.title))
     return utils.LaxVocabulary(terms)
+
+
 zope.interface.alsoProvides(scheduler_vocabulary,
                             zope.schema.interfaces.IVocabularyFactory)
 
+
 class ChannelEditForm(crud.EditForm):
+
     def _update_subforms(self):
         self.subforms = []
         for channel in collective.singing.channel.channel_lookup():
@@ -96,6 +105,7 @@ class ChannelEditForm(crud.EditForm):
             subform.content_id = channel.name
             subform.update()
             self.subforms.append(subform)
+
 
 class ManageChannelsForm(crud.CrudForm):
     """Crud form for channels."""
@@ -186,6 +196,7 @@ class ChannelAdministrationView(BrowserView):
         switch_on(self)
         return ManageChannelsForm(self.context.channels, self.request)()
 
+
 class SubscriptionsSearchForm(z3c.form.form.Form):
     prefix = 'search.'
     ignoreContext = True
@@ -200,7 +211,9 @@ class SubscriptionsSearchForm(z3c.form.form.Form):
     def handle_search(self, action):
         pass
 
+
 class ManageSubscriptionsFormEdit(crud.EditForm):
+
     def update(self):
         super(ManageSubscriptionsFormEdit, self).update()
         self.search = SubscriptionsSearchForm(self.context, self.request)
@@ -217,6 +230,7 @@ class ManageSubscriptionsFormEdit(crud.EditForm):
             table = table[:idx] + hidden + table[idx:]
         return ('<div id="subscriber-search">%s</div>' % self.search.render() +
                 table)
+
 
 class ManageSubscriptionsForm(crud.CrudForm):
     """Crud form for subscriptions.
@@ -319,6 +333,7 @@ class SubscriptionChoiceFieldDataManager(z3c.form.datamanager.AttributeField):
             if issubclass(self.field.interface, ICollectorSchema):
                 self.field.interface = ICollectorSchema
 
+
 class ChannelPreviewForm(z3c.form.form.Form):
     """Channel preview form.
 
@@ -351,6 +366,7 @@ class ChannelPreviewForm(z3c.form.form.Form):
             self.context.absolute_url() + \
             '/preview-newsletter.html?include_collector_items=%d' % \
             collector_items)
+
 
 class EditChannelForm(z3c.form.form.EditForm):
     """Channel edit form.
@@ -495,7 +511,8 @@ class ExportCSV(BrowserView):
                     title_id = optional.title.strip() + ' (' + optional.id + ')'
                     collectors_keys.append(title_id)
         subscription_data = [
-            'creation_date', 'pending', 'format', 'language', 'cue', 'secret']
+            'creation_date', 'pending', 'unsubscribed', 'format', 'language',
+            'cue', 'secret']
         for format in self.context.composers.keys():
             composers_keys = field.Fields(
                 self.context.composers[format].schema).keys()
@@ -523,6 +540,7 @@ class ExportCSV(BrowserView):
                 # add subsciption_data
                 row.append(subscription.metadata.get('date', ''))
                 row.append(subscription.metadata.get('pending', 'imported'))
+                row.append(subscription.metadata.get('unsubscribed', ''))
                 row.append(subscription.metadata.get('format', ''))
                 row.append(subscription.metadata.get('language', ''))
                 row.append(subscription.metadata.get(
@@ -718,7 +736,7 @@ class UploadForm(crud.AddForm):
                             item.collector_data = {}
 
                     added += 1
-                except Exception, e: # XXX refine which exceptions we want to catch
+                except Exception, e:  # XXX refine which exceptions we want to catch
                     # TODO; put some information about error e into the message
                     errorcandidates.append(subscriber_data.get('email',
                                                                _(u'Unknown')))
@@ -783,6 +801,7 @@ class UploadForm(crud.AddForm):
         self.status = _(u"Subscribers exported.")
         return self.request.response.redirect(self.mychannel.absolute_url() + \
                                               '/export')
+
 
 class ManageUploadForm(crud.CrudForm):
     description = _(u"Upload list of subscribers.")

--- a/collective/dancing/channel.py
+++ b/collective/dancing/channel.py
@@ -50,8 +50,10 @@ def portal_newsletters():
     else:
         return []
 
+
 interface.directlyProvides(portal_newsletters,
                            collective.singing.interfaces.IChannelLookup)
+
 
 class Salt(UserString):
     """
@@ -69,6 +71,7 @@ class Salt(UserString):
             for i in range(50)])
         UserString.__init__(self, salt)
 
+
 class INewslettersSettings(interface.Interface):
     use_single_form_subscriptions_page = schema.Bool(
         title=_(u"Use single form subscriptions page"),
@@ -76,8 +79,10 @@ class INewslettersSettings(interface.Interface):
         default=False,
         required=False)
 
+
 class IPortalNewsletters(INewslettersSettings):
     pass
+
 
 class PortalNewsletters(OFS.Folder.Folder):
     interface.implements(IPortalNewsletters)
@@ -86,6 +91,7 @@ class PortalNewsletters(OFS.Folder.Folder):
 
     def Title(self):
         return _(u"Newsletters")
+
 
 @component.adapter(IPortalNewsletters,
                    zopeappcontainerinterfaces.IObjectAddedEvent)
@@ -104,8 +110,10 @@ def tool_added(tool, event):
     sm = component.getSiteManager(tool)
     sm.registerUtility(salt, collective.singing.interfaces.ISalt)
 
+
 class IChannelContainer(interface.Interface):
     pass
+
 
 class ChannelContainer(OFS.Folder.Folder):
     interface.implements(IChannelContainer)
@@ -115,8 +123,10 @@ class ChannelContainer(OFS.Folder.Folder):
       >>> container.objectIds()
       ['your-channel']
     """
+
     def Title(self):
         return u"Mailing-lists"
+
 
 @component.adapter(IChannelContainer,
                    zopeappcontainerinterfaces.IObjectAddedEvent)
@@ -124,6 +134,7 @@ def channels_added(container, event):
     if 'default-channel' not in container.objectIds():
         default_channel = Channel('default-channel', title=_(u"Newsletter"))
         container['default-channel'] = default_channel
+
 
 class Channel(OFS.SimpleItem.SimpleItem):
     """
@@ -170,6 +181,7 @@ class Channel(OFS.SimpleItem.SimpleItem):
     def Title(self):
         return self.title
 
+
 @component.adapter(Channel,
                    zopeappcontainerinterfaces.IObjectAddedEvent)
 def channel_added(channel, event):
@@ -195,6 +207,7 @@ def channel_added(channel, event):
         # This will finally catalog the subscription:
         collective.singing.subscribe.subscription_added(subscription, None)
 
+
 @component.adapter(collective.singing.interfaces.ICollector,
                    zopeappcontainerinterfaces.IObjectRemovedEvent)
 def collector_removed(collector, event):
@@ -217,6 +230,7 @@ class SubscriptionsFromScriptChannel(Channel):
         # might delete it in the future.
         # and the email is unique
         self.subscriptions_metadata = persistent.dict.PersistentDict()
+
 
 # This lists of factories is mutable: You can add to it:
 channels = [Channel, SubscriptionsFromScriptChannel]

--- a/collective/dancing/subscribe.py
+++ b/collective/dancing/subscribe.py
@@ -18,6 +18,7 @@ class Subscription(collective.singing.subscribe.SimpleSubscription):
 
     @apply
     def channel():
+
         def get(self):
             if self._channel is not None:
                 all_channels = list(collective.singing.channel.channel_lookup())
@@ -39,6 +40,7 @@ class Subscription(collective.singing.subscribe.SimpleSubscription):
 
         def set(self, channel):
             self._channel = channel
+
         return property(get, set)
 
 
@@ -123,7 +125,11 @@ class SubscriptionFromDictionary(SimpleSubscription):
             composer_data.update(data["subscriber_data"])
 
         # default the pending value to False
-        metadata = dict(format="html", pending=False)
+        metadata = dict(
+            format="html",
+            pending=False,
+            unsubscribed=None)
+
         if isinstance(data["format"], basestring) and \
            data["format"]:
             metadata["format"] = data["format"]

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- When unsubscribing from a channel, do not delete subscription but mark it as
+  `unsubscribed`. This allows to find out who unsubscribed when re-importing
+  subscriptions from other systems. (fixes #15) [fRiSi]
+
 - Fix tests by (temporarily) pinning Plone 4.3.x to 4.3.11
   and dropping support for Python2.6 (Plone 4.0 and 4.1)
 

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -11,7 +11,7 @@ auto-checkout =
 
 
 [sources]
-collective.singing = git https://github.com/collective/collective.singing
+collective.singing = git https://github.com/collective/collective.singing branch=track-unsubscribes
 
 
 [versions]

--- a/test-plone-4.x.cfg
+++ b/test-plone-4.x.cfg
@@ -13,4 +13,4 @@ auto-checkout =
 
 
 [sources]
-collective.singing = git https://github.com/collective/collective.singing
+collective.singing = git https://github.com/collective/collective.singing branch=track-unsubscribes


### PR DESCRIPTION
instead of simply deleting them.

this is a major change in how subscriptions are handled and requires
quite a lot of changes.
the benefit is, that we can track unsubscriptions now

* we know when they happened (date is included in the csv export)
* we can skip unsubscribed users when re-importing users from an
external data source

.. ATTENTION:: requires an update of collective.singing too

this fixes https://github.com/collective/collective.dancing/issues/15